### PR TITLE
Update Invoice and Order line items specifically the `Rate` field

### DIFF
--- a/lib/qbwc/request/invoices.rb
+++ b/lib/qbwc/request/invoices.rb
@@ -385,7 +385,7 @@ module QBWC
 
           <<-XML
 
-      <Rate>#{'%.2f' % line['price'].to_f}</Rate>
+      <Rate>#{'%.2f' % price(line).to_f}</Rate>
           XML
         end
 
@@ -434,6 +434,10 @@ module QBWC
         end
 
         private
+
+        def price(line)
+          line['line_item_price'] || line['price']
+        end
 
         def items(record)
           record['line_items'].to_a.sort_by { |a| a['product_id'] }

--- a/lib/qbwc/request/orders.rb
+++ b/lib/qbwc/request/orders.rb
@@ -287,7 +287,7 @@ module QBWC
 
           <<-XML
 
-      <Rate>#{'%.2f' % line['price'].to_f}</Rate>
+      <Rate>#{'%.2f' % price(line).to_f}</Rate>
           XML
         end
 
@@ -353,6 +353,11 @@ module QBWC
         end
 
         private
+
+        def price(line)
+          line['line_item_price'] || line['price']
+        end
+
 
         def items(record)
           record['line_items'].to_a.sort { |a, b| a['product_id'] <=> b['product_id'] }


### PR DESCRIPTION
- Look for `line_item_price` before using the `price` field. Allows for
backwards compatibility while we start using relationships feature in
different integrations