### PR TITLE
Removed "restart: always" from docker-compose, since I don't want thi…

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -11,3 +11,4 @@ services:
     network_mode: bridge
     logging:
       driver: gcplogs
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,3 @@ services:
       - AWS_ACCESS_KEY_ID=ENV[AWS_ACCESS_KEY_ID]
       - AWS_SECRET_ACCESS_KEY=ENV[AWS_SECRET_ACCESS_KEY]
       - AWS_REGION=ENV[AWS_REGION]
-    restart: always


### PR DESCRIPTION
…s thing

restarting on my local env.
However I moved it to docker-compose.production: we want that running FOREVER (or until Cloud Run, at least...)