### PR TITLE
Added tests for product types coming from a config hash

### DIFF
--- a/lib/qbwc/request/products.rb
+++ b/lib/qbwc/request/products.rb
@@ -187,7 +187,7 @@ module QBWC
 
         private
 
-        def build_polling_from_config_param(params, session, time)
+        def build_polling_from_config_param(params, session_id, time)
           JSON.parse(params['quickbooks_specify_products']).map do |value|
             next unless PRODUCT_TYPES.has_key?(value.to_sym)
             <<~XML


### PR DESCRIPTION
I was having issues with the JSON hash sent in as a param, so when debugging I wrote a test to make sure it was working