### PR TITLE
Fix/sales purchase issues noninvprods

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ You can also call `/get_products` and specify a config value - see below
   # NOTE: Be sure to escape the string values of each item in the "array"
 ```
 
+### Adding Products
+
+QBE has a few different product types that FlowLink allows you to add/mod/query
+
+* inventory
+* assembly
+* noninventory
+* salestax
+* service
+* discount
+
+When **adding** noninventory or service products, the block of either SalesOrPurchase or SalesAndPurchase is required. To specify which block to use, you'll need to set the field to true. `sales_and_purchase = true` or `sales_or_purchase = true`. If both are set to true or neither are set, SalesAndPurchase is the default block.
+
+When **modifying** noninventory or service products, these blocks are not required. If both `sales_and_purchase` and `sales_or_purchase` are set to true, SalesAndPurchase is still the default. If none are set, these blocks will be ignored.
+
+Some products do not allow modifying of the SalesOrPurchase and SalesAndPurchase block, so be sure you can modify when you send the request.
+
 ## About FlowLink
 
 [FlowLink](http://flowlink.io/) allows you to connect to your own custom integrations.

--- a/lib/qbwc/request/noninventoryproducts.rb
+++ b/lib/qbwc/request/noninventoryproducts.rb
@@ -105,7 +105,7 @@ module QBWC
             #{add_barcode(product)}
             <IsActive >#{product['is_active'] || true}</IsActive>
             #{add_fields(product, GENERAL_MAPPING, config, is_mod)}
-            #{sale_or_and_purchase(product, config, is_mod)}
+            #{sales_or_and_purchase(product, config, is_mod)}
             #{add_fields(product, EXTERNAL_GUID_MAP, config, is_mod)}
           XML
         end
@@ -150,16 +150,16 @@ module QBWC
           XML
         end
 
-        def sale_or_and_purchase(product, config, is_mod)
-          map = product['sale_or_purchase'] ? SALES_OR_PURCHASE_MAP : SALES_AND_PURCHASE_MAP
-          tag = "SalesAndPurchase"
-
-          if product['sale_or_purchase'] && is_mod
-            tag = "SalesOrPurchaseMod"
-          elsif product['sale_or_purchase']
-            tag = "SalesOrPurchase"
-          elsif is_mod
-            tag = "SalesAndPurchaseMod"
+        def sales_or_and_purchase(product, config, is_mod)
+          return "" unless !is_mod || product['sales_or_purchase'] || product['sales_and_purchase']
+          
+          # SandP or SorP is required when adding. We default to Sales and Purchase here.
+          map = SALES_AND_PURCHASE_MAP
+          tag = is_mod ? "SalesAndPurchaseMod" : "SalesAndPurchase"
+          
+          if product['sales_or_purchase']
+            map = SALES_OR_PURCHASE_MAP
+            tag = is_mod ? "SalesOrPurchaseMod" : "SalesOrPurchase"
           end
 
           # We should only have either price OR price_percent, so we default to price here

--- a/lib/qbwc/request/noninventoryproducts.rb
+++ b/lib/qbwc/request/noninventoryproducts.rb
@@ -157,7 +157,7 @@ module QBWC
           map = SALES_AND_PURCHASE_MAP
           tag = is_mod ? "SalesAndPurchaseMod" : "SalesAndPurchase"
           
-          if product['sales_or_purchase']
+          if product['sales_or_purchase'] && product['sales_and_purchase'] != true
             map = SALES_OR_PURCHASE_MAP
             tag = is_mod ? "SalesOrPurchaseMod" : "SalesOrPurchase"
           end

--- a/lib/qbwc/request/serviceproducts.rb
+++ b/lib/qbwc/request/serviceproducts.rb
@@ -156,7 +156,7 @@ module QBWC
           map = SALES_AND_PURCHASE_MAP
           tag = is_mod ? "SalesAndPurchaseMod" : "SalesAndPurchase"
           
-          if product['sales_or_purchase']
+          if product['sales_or_purchase'] && product['sales_and_purchase'] != true
             map = SALES_OR_PURCHASE_MAP
             tag = is_mod ? "SalesOrPurchaseMod" : "SalesOrPurchase"
           end

--- a/lib/qbwc/request/serviceproducts.rb
+++ b/lib/qbwc/request/serviceproducts.rb
@@ -104,7 +104,7 @@ module QBWC
             #{add_barcode(product)}
             <IsActive >#{product['is_active'] || true}</IsActive>
             #{add_fields(product, GENERAL_MAPPING, config, is_mod)}
-            #{sale_or_and_purchase(product, config, is_mod)}
+            #{sales_or_and_purchase(product, config, is_mod)}
             #{add_fields(product, EXTERNAL_GUID_MAP, config, is_mod)}
           XML
         end
@@ -149,16 +149,16 @@ module QBWC
           XML
         end
 
-        def sale_or_and_purchase(product, config, is_mod)
-          map = product['sale_or_purchase'] ? SALES_OR_PURCHASE_MAP : SALES_AND_PURCHASE_MAP
-          tag = "SalesAndPurchase"
-
-          if product['sale_or_purchase'] && is_mod
-            tag = "SalesOrPurchaseMod"
-          elsif product['sale_or_purchase']
-            tag = "SalesOrPurchase"
-          elsif is_mod
-            tag = "SalesAndPurchaseMod"
+        def sales_or_and_purchase(product, config, is_mod)
+          return "" unless !is_mod || product['sales_or_purchase'] || product['sales_and_purchase']
+          
+          # SandP or SorP is required when adding. We default to Sales and Purchase here.
+          map = SALES_AND_PURCHASE_MAP
+          tag = is_mod ? "SalesAndPurchaseMod" : "SalesAndPurchase"
+          
+          if product['sales_or_purchase']
+            map = SALES_OR_PURCHASE_MAP
+            tag = is_mod ? "SalesOrPurchaseMod" : "SalesOrPurchase"
           end
 
           # We should only have either price OR price_percent, so we default to price here

--- a/spec/qbwc/request/noninventoryproduct_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/noninventoryproduct_fixtures/add_update_search_xml_fixtures.rb
@@ -198,6 +198,64 @@ def update_xml_sorp_with_percent_noninventoryproduct
   XML
 end
 
+def add_xml_basic_noninventoryproduct
+  <<~XML
+    <ItemNonInventoryAddRq requestID="12345">
+      <ItemNonInventoryAdd>
+        <Name>test noninv product</Name>
+        <BarCode>
+          <BarCodeValue>0001910191</BarCodeValue>
+          <AssignEvenIfUsed>true</AssignEvenIfUsed>
+          <AllowOverride>false</AllowOverride>
+        </BarCode>
+        <IsActive>true</IsActive>
+        <ParentRef><FullName>GermanCars:Mercedes-Benz</FullName></ParentRef>
+        <ClassRef><FullName>Class1:Class2</FullName></ClassRef>
+        <ManufacturerPartNumber>partnumber123</ManufacturerPartNumber>
+        <UnitOfMeasureSetRef><FullName>feet</FullName></UnitOfMeasureSetRef>
+        <IsTaxIncluded>false</IsTaxIncluded>
+        <SalesTaxCodeRef><FullName>tax</FullName></SalesTaxCodeRef>
+        <SalesAndPurchase>
+          <SalesDesc>This product is non inventory</SalesDesc>
+          <SalesPrice>20.00</SalesPrice>
+          <IncomeAccountRef><FullName>Income Account</FullName></IncomeAccountRef>
+          <PurchaseDesc>This product is non inventory and available for purchase</PurchaseDesc>
+          <PurchaseCost>5.00</PurchaseCost>
+          <PurchaseTaxCodeRef><FullName>standard tax</FullName></PurchaseTaxCodeRef>
+          <ExpenseAccountRef><FullName>Expense Account</FullName></ExpenseAccountRef>
+          <PrefVendorRef><FullName>Sully's Hot Dog Stand</FullName></PrefVendorRef>
+        </SalesAndPurchase>
+        <ExternalGUID>109389220</ExternalGUID>
+      </ItemNonInventoryAdd>
+    </ItemNonInventoryAddRq>
+  XML
+end
+
+def update_xml_basic_noninventoryproduct
+  <<~XML
+    <ItemNonInventoryModRq requestID="12345">
+      <ItemNonInventoryMod>
+        <ListID>test noninv product</ListID>
+        <EditSequence>19209j3od-d9292</EditSequence>
+        <Name>test noninv product</Name>
+        <BarCode>
+          <BarCodeValue>0001910191</BarCodeValue>
+          <AssignEvenIfUsed>true</AssignEvenIfUsed>
+          <AllowOverride>false</AllowOverride>
+        </BarCode>
+        <IsActive>true</IsActive>
+        <ParentRef><FullName>GermanCars:Mercedes-Benz</FullName></ParentRef>
+        <ClassRef><FullName>Class1:Class2</FullName></ClassRef>
+        <ManufacturerPartNumber>partnumber123</ManufacturerPartNumber>
+        <UnitOfMeasureSetRef><FullName>feet</FullName></UnitOfMeasureSetRef>
+        <ForceUOMChange>true</ForceUOMChange>
+        <IsTaxIncluded>false</IsTaxIncluded>
+        <SalesTaxCodeRef><FullName>tax</FullName></SalesTaxCodeRef>
+      </ItemNonInventoryMod>
+    </ItemNonInventoryModRq>
+  XML
+end
+
 def update_xml_with_active_field_noninventoryproduct
   <<~XML
     <ItemNonInventoryModRq requestID="12345">

--- a/spec/qbwc/request/noninventoryproduct_spec.rb
+++ b/spec/qbwc/request/noninventoryproduct_spec.rb
@@ -55,12 +55,14 @@ RSpec.describe QBWC::Request::Noninventoryproducts do
     }
     
     it "matches expected xml when adding sales and purchase" do
+      flowlink_product["sales_and_purchase"] = true
+
       product = QBWC::Request::Noninventoryproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
       expect(product.gsub(/\s+/, "")).to eq(add_xml_sandp_noninventoryproduct.gsub(/\s+/, ""))
     end
 
     it "matches expected xml when adding sales or purchase with percent field" do
-      flowlink_product["sale_or_purchase"] = true
+      flowlink_product["sales_or_purchase"] = true
       flowlink_product["price"] = nil
 
       product = QBWC::Request::Noninventoryproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
@@ -68,13 +70,22 @@ RSpec.describe QBWC::Request::Noninventoryproducts do
     end
 
     it "matches expected xml when adding sales or purchase without percent field" do
-      flowlink_product["sale_or_purchase"] = true
+      flowlink_product["sales_or_purchase"] = true
 
       product = QBWC::Request::Noninventoryproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
       expect(product.gsub(/\s+/, "")).to eq(add_xml_sorp_without_percent_noninventoryproduct.gsub(/\s+/, ""))
     end
-    
+
+    it "matches expected xml when adding basic product (no sales_or_purchase and no sales_and_purchase)" do
+      flowlink_product["sales_or_purchase"] = nil
+      flowlink_product["sales_and_purchase"] = nil
+
+      product = QBWC::Request::Noninventoryproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
+      expect(product.gsub(/\s+/, "")).to eq(add_xml_basic_noninventoryproduct.gsub(/\s+/, ""))
+    end
+
     it "matches expected xml when updating sales and purchase" do
+      flowlink_product["sales_and_purchase"] = true
       flowlink_product["list_id"] = "test noninv product"
       flowlink_product["edit_sequence"] = "19209j3od-d9292"
 
@@ -83,7 +94,7 @@ RSpec.describe QBWC::Request::Noninventoryproducts do
     end
 
     it "matches expected xml when updating sales or purchase with percent field" do
-      flowlink_product["sale_or_purchase"] = true
+      flowlink_product["sales_or_purchase"] = true
       flowlink_product["list_id"] = "test noninv product"
       flowlink_product["edit_sequence"] = "19209j3od-d9292"
       flowlink_product["price"] = nil
@@ -93,12 +104,22 @@ RSpec.describe QBWC::Request::Noninventoryproducts do
     end
 
     it "it matches expected xml when updating sales or purchase without percent field" do
-      flowlink_product["sale_or_purchase"] = true
+      flowlink_product["sales_or_purchase"] = true
       flowlink_product["list_id"] = "test noninv product"
       flowlink_product["edit_sequence"] = "19209j3od-d9292"
       
       product = QBWC::Request::Noninventoryproducts.update_xml_to_send(flowlink_product, nil, 12345, config)
       expect(product.gsub(/\s+/, "")).to eq(update_xml_sorp_without_percent_noninventoryproduct.gsub(/\s+/, ""))
+    end
+
+    it "matches expected xml when updating basic product (no sales_or_purchase and no sales_and_purchase)" do
+      flowlink_product["sales_or_purchase"] = nil
+      flowlink_product["sales_and_purchase"] = nil
+      flowlink_product["list_id"] = "test noninv product"
+      flowlink_product["edit_sequence"] = "19209j3od-d9292"
+
+      product = QBWC::Request::Noninventoryproducts.update_xml_to_send(flowlink_product, nil, 12345, config)
+      expect(product.gsub(/\s+/, "")).to eq(update_xml_basic_noninventoryproduct.gsub(/\s+/, ""))
     end
 
     it "it matches expected xml when updating noninventory product with active field" do

--- a/spec/qbwc/request/noninventoryproduct_spec.rb
+++ b/spec/qbwc/request/noninventoryproduct_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe QBWC::Request::Noninventoryproducts do
       expect(product.gsub(/\s+/, "")).to eq(add_xml_basic_noninventoryproduct.gsub(/\s+/, ""))
     end
 
+    it "matches expected xml when adding basic product with both sales_or_purchase and sales_and_purchase fields set to true" do
+      flowlink_product["sales_or_purchase"] = true
+      flowlink_product["sales_and_purchase"] = true
+
+      product = QBWC::Request::Noninventoryproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
+      expect(product.gsub(/\s+/, "")).to eq(add_xml_basic_noninventoryproduct.gsub(/\s+/, ""))
+    end
+
     it "matches expected xml when updating sales and purchase" do
       flowlink_product["sales_and_purchase"] = true
       flowlink_product["list_id"] = "test noninv product"
@@ -120,6 +128,16 @@ RSpec.describe QBWC::Request::Noninventoryproducts do
 
       product = QBWC::Request::Noninventoryproducts.update_xml_to_send(flowlink_product, nil, 12345, config)
       expect(product.gsub(/\s+/, "")).to eq(update_xml_basic_noninventoryproduct.gsub(/\s+/, ""))
+    end
+
+    it "matches expected xml when updating basic product with both sales_or_purchase and sales_and_purchase fields set to true" do
+      flowlink_product["sales_or_purchase"] = true
+      flowlink_product["sales_and_purchase"] = true
+      flowlink_product["list_id"] = "test noninv product"
+      flowlink_product["edit_sequence"] = "19209j3od-d9292"
+
+      product = QBWC::Request::Noninventoryproducts.update_xml_to_send(flowlink_product, nil, 12345, config)
+      expect(product.gsub(/\s+/, "")).to eq(update_xml_sandp_noninventoryproduct.gsub(/\s+/, ""))
     end
 
     it "it matches expected xml when updating noninventory product with active field" do

--- a/spec/qbwc/request/serviceproduct_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/serviceproduct_fixtures/add_update_search_xml_fixtures.rb
@@ -192,6 +192,62 @@ def update_xml_sorp_with_percent_serviceproduct
   XML
 end
 
+def add_xml_basic_serviceproduct
+  <<~XML
+    <ItemServiceAddRq requestID="12345">
+      <ItemServiceAdd>
+        <Name>test service product</Name>
+        <BarCode>
+          <BarCodeValue>0001910191</BarCodeValue>
+          <AssignEvenIfUsed>true</AssignEvenIfUsed>
+          <AllowOverride>false</AllowOverride>
+        </BarCode>
+        <IsActive>true</IsActive>
+        <ClassRef><FullName>Class1:Class2</FullName></ClassRef>
+        <ParentRef><FullName>GermanCars:Mercedes-Benz</FullName></ParentRef>
+        <UnitOfMeasureSetRef><FullName>feet</FullName></UnitOfMeasureSetRef>
+        <IsTaxIncluded>false</IsTaxIncluded>
+        <SalesTaxCodeRef><FullName>tax</FullName></SalesTaxCodeRef>
+        <SalesAndPurchase>
+          <SalesDesc>This product is service</SalesDesc>
+          <SalesPrice>20.00</SalesPrice>
+          <IncomeAccountRef><FullName>Income Account</FullName></IncomeAccountRef>
+          <PurchaseDesc>This product is service and available for purchase</PurchaseDesc>
+          <PurchaseCost>5.00</PurchaseCost>
+          <PurchaseTaxCodeRef><FullName>standard tax</FullName></PurchaseTaxCodeRef>
+          <ExpenseAccountRef><FullName>Expense Account</FullName></ExpenseAccountRef>
+          <PrefVendorRef><FullName>Sully's Hot Dog Stand</FullName></PrefVendorRef>
+        </SalesAndPurchase>
+        <ExternalGUID>109389220</ExternalGUID>
+      </ItemServiceAdd>
+    </ItemServiceAddRq>
+  XML
+end
+
+def update_xml_basic_serviceproduct
+  <<~XML
+    <ItemServiceModRq requestID="12345">
+      <ItemServiceMod>
+        <ListID>test service product</ListID>
+        <EditSequence>19209j3od-d9292</EditSequence>
+        <Name>test service product</Name>
+        <BarCode>
+          <BarCodeValue>0001910191</BarCodeValue>
+          <AssignEvenIfUsed>true</AssignEvenIfUsed>
+          <AllowOverride>false</AllowOverride>
+        </BarCode>
+        <IsActive>true</IsActive>
+        <ClassRef><FullName>Class1:Class2</FullName></ClassRef>
+        <ParentRef><FullName>GermanCars:Mercedes-Benz</FullName></ParentRef>
+        <UnitOfMeasureSetRef><FullName>feet</FullName></UnitOfMeasureSetRef>
+        <ForceUOMChange>true</ForceUOMChange>
+        <IsTaxIncluded>false</IsTaxIncluded>
+        <SalesTaxCodeRef><FullName>tax</FullName></SalesTaxCodeRef>
+      </ItemServiceMod>
+    </ItemServiceModRq>
+  XML
+end
+
 def update_xml_with_active_field_serviceproduct
   <<~XML
     <ItemServiceModRq requestID="12345">

--- a/spec/qbwc/request/serviceproduct_spec.rb
+++ b/spec/qbwc/request/serviceproduct_spec.rb
@@ -55,12 +55,14 @@ RSpec.describe QBWC::Request::Serviceproducts do
     }
     
     it "matches expected xml when adding sales and purchase" do
+      flowlink_product["sales_and_purchase"] = true
+
       product = QBWC::Request::Serviceproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
       expect(product.gsub(/\s+/, "")).to eq(add_xml_sandp_serviceproduct.gsub(/\s+/, ""))
     end
 
     it "matches expected xml when adding sales or purchase with percent field" do
-      flowlink_product["sale_or_purchase"] = true
+      flowlink_product["sales_or_purchase"] = true
       flowlink_product["price"] = nil
 
       product = QBWC::Request::Serviceproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
@@ -68,13 +70,22 @@ RSpec.describe QBWC::Request::Serviceproducts do
     end
 
     it "matches expected xml when adding sales or purchase without percent field" do
-      flowlink_product["sale_or_purchase"] = true
+      flowlink_product["sales_or_purchase"] = true
 
       product = QBWC::Request::Serviceproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
       expect(product.gsub(/\s+/, "")).to eq(add_xml_sorp_without_percent_serviceproduct.gsub(/\s+/, ""))
     end
+
+    it "matches expected xml when adding basic product (no sales_or_purchase and no sales_and_purchase)" do
+      flowlink_product["sales_or_purchase"] = nil
+      flowlink_product["sales_and_purchase"] = nil
+
+      product = QBWC::Request::Serviceproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
+      expect(product.gsub(/\s+/, "")).to eq(add_xml_basic_serviceproduct.gsub(/\s+/, ""))
+    end
     
     it "matches expected xml when updating sales and purchase" do
+      flowlink_product["sales_and_purchase"] = true
       flowlink_product["list_id"] = "test service product"
       flowlink_product["edit_sequence"] = "19209j3od-d9292"
 
@@ -83,7 +94,7 @@ RSpec.describe QBWC::Request::Serviceproducts do
     end
 
     it "matches expected xml when updating sales or purchase with percent field" do
-      flowlink_product["sale_or_purchase"] = true
+      flowlink_product["sales_or_purchase"] = true
       flowlink_product["list_id"] = "test service product"
       flowlink_product["edit_sequence"] = "19209j3od-d9292"
       flowlink_product["price"] = nil
@@ -93,12 +104,22 @@ RSpec.describe QBWC::Request::Serviceproducts do
     end
 
     it "it matches expected xml when updating sales or purchase without percent field" do
-      flowlink_product["sale_or_purchase"] = true
+      flowlink_product["sales_or_purchase"] = true
       flowlink_product["list_id"] = "test service product"
       flowlink_product["edit_sequence"] = "19209j3od-d9292"
       
       product = QBWC::Request::Serviceproducts.update_xml_to_send(flowlink_product, nil, 12345, config)
       expect(product.gsub(/\s+/, "")).to eq(update_xml_sorp_without_percent_serviceproduct.gsub(/\s+/, ""))
+    end
+
+    it "matches expected xml when updating basic product (no sales_or_purchase and no sales_and_purchase)" do
+      flowlink_product["sales_or_purchase"] = nil
+      flowlink_product["sales_and_purchase"] = nil
+      flowlink_product["list_id"] = "test service product"
+      flowlink_product["edit_sequence"] = "19209j3od-d9292"
+
+      product = QBWC::Request::Serviceproducts.update_xml_to_send(flowlink_product, nil, 12345, config)
+      expect(product.gsub(/\s+/, "")).to eq(update_xml_basic_serviceproduct.gsub(/\s+/, ""))
     end
 
     it "it matches expected xml when updating service product with active field" do

--- a/spec/qbwc/request/serviceproduct_spec.rb
+++ b/spec/qbwc/request/serviceproduct_spec.rb
@@ -83,6 +83,14 @@ RSpec.describe QBWC::Request::Serviceproducts do
       product = QBWC::Request::Serviceproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
       expect(product.gsub(/\s+/, "")).to eq(add_xml_basic_serviceproduct.gsub(/\s+/, ""))
     end
+
+    it "matches expected xml when adding basic product with both sales_or_purchase and sales_and_purchase fields set to true" do
+      flowlink_product["sales_or_purchase"] = true
+      flowlink_product["sales_and_purchase"] = true
+
+      product = QBWC::Request::Serviceproducts.add_xml_to_send(flowlink_product, nil, 12345, config)
+      expect(product.gsub(/\s+/, "")).to eq(add_xml_basic_serviceproduct.gsub(/\s+/, ""))
+    end
     
     it "matches expected xml when updating sales and purchase" do
       flowlink_product["sales_and_purchase"] = true
@@ -120,6 +128,16 @@ RSpec.describe QBWC::Request::Serviceproducts do
 
       product = QBWC::Request::Serviceproducts.update_xml_to_send(flowlink_product, nil, 12345, config)
       expect(product.gsub(/\s+/, "")).to eq(update_xml_basic_serviceproduct.gsub(/\s+/, ""))
+    end
+
+    it "matches expected xml when updating basic product with both sales_or_purchase and sales_and_purchase fields set to true" do
+      flowlink_product["sales_or_purchase"] = true
+      flowlink_product["sales_and_purchase"] = true
+      flowlink_product["list_id"] = "test service product"
+      flowlink_product["edit_sequence"] = "19209j3od-d9292"
+
+      product = QBWC::Request::Serviceproducts.update_xml_to_send(flowlink_product, nil, 12345, config)
+      expect(product.gsub(/\s+/, "")).to eq(update_xml_sandp_serviceproduct.gsub(/\s+/, ""))
     end
 
     it "it matches expected xml when updating service product with active field" do


### PR DESCRIPTION
QBE has a few different product types that FlowLink allows you to add/mod/query

* inventory
* assembly
* noninventory
* salestax
* service
* discount

When **adding** noninventory or service products, the block of either SalesOrPurchase or SalesAndPurchase is required. To specify which block to use, you'll need to set the field to true. `sales_and_purchase = true` or `sales_or_purchase = true`. If both are set to true or neither are set, SalesAndPurchase is the default block.

When **modifying** noninventory or service products, these blocks are not required. If both `sales_and_purchase` and `sales_or_purchase` are set to true, SalesAndPurchase is still the default. If none are set, these blocks will be ignored.

Some products do not allow modifying of the SalesOrPurchase and SalesAndPurchase block, so be sure you can modify when you send the request.