### PR TITLE
Fix/return all

### DIFF
--- a/lib/qbwc/request/discountproducts.rb
+++ b/lib/qbwc/request/discountproducts.rb
@@ -52,7 +52,7 @@ module QBWC
         def search_xml_by_name(object_id, session_id)
           <<~XML
             <ItemDiscountQueryRq requestID="#{session_id}">
-              <MaxReturned>50</MaxReturned>
+              <MaxReturned>10000</MaxReturned>
               <NameRangeFilter>
                 <FromName>#{object_id}</FromName>
                 <ToName>#{object_id}</ToName>

--- a/lib/qbwc/request/discountproducts.rb
+++ b/lib/qbwc/request/discountproducts.rb
@@ -33,17 +33,29 @@ module QBWC
             config = { connection_id: params['connection_id'] }.with_indifferent_access
             session_id = Persistence::Session.save(config, object)
 
-            request << search_xml(product_identifier(object), session_id)
+            if object['list_id'].to_s.empty?
+              request << search_xml_by_name(product_identifier(object), session_id)
+            else
+              request << search_xml_by_id(object['list_id'], session_id)
+            end
           end
         end
 
-        def search_xml(product_id, session_id)
+        def search_xml_by_id(object_id, session_id)
           <<~XML
             <ItemDiscountQueryRq requestID="#{session_id}">
-              <MaxReturned>10000</MaxReturned>
+              <ListID>#{object_id}</ListID>
+            </ItemDiscountQueryRq>
+          XML
+        end
+
+        def search_xml_by_name(object_id, session_id)
+          <<~XML
+            <ItemDiscountQueryRq requestID="#{session_id}">
+              <MaxReturned>50</MaxReturned>
               <NameRangeFilter>
-                <FromName>#{product_id}</FromName>
-                <ToName>#{product_id}</ToName>
+                <FromName>#{object_id}</FromName>
+                <ToName>#{object_id}</ToName>
               </NameRangeFilter>
             </ItemDiscountQueryRq>
           XML

--- a/lib/qbwc/request/noninventoryproducts.rb
+++ b/lib/qbwc/request/noninventoryproducts.rb
@@ -54,17 +54,29 @@ module QBWC
             config = { connection_id: params['connection_id'] }.with_indifferent_access
             session_id = Persistence::Session.save(config, object)
 
-            request << search_xml(product_identifier(object), session_id)
+            if object['list_id'].to_s.empty?
+              request << search_xml_by_name(product_identifier(object), session_id)
+            else
+              request << search_xml_by_id(object['list_id'], session_id)
+            end
           end
         end
 
-        def search_xml(product_id, session_id)
+        def search_xml_by_id(object_id, session_id)
+          <<~XML
+            <ItemNonInventoryQueryRq requestID="#{session_id}">
+              <ListID>#{object_id}</ListID>
+            </ItemNonInventoryQueryRq>
+          XML
+        end
+
+        def search_xml_by_name(object_id, session_id)
           <<~XML
             <ItemNonInventoryQueryRq requestID="#{session_id}">
               <MaxReturned>10000</MaxReturned>
               <NameRangeFilter>
-                <FromName>#{product_id}</FromName>
-                <ToName>#{product_id}</ToName>
+                <FromName>#{object_id}</FromName>
+                <ToName>#{object_id}</ToName>
               </NameRangeFilter>
             </ItemNonInventoryQueryRq>
           XML

--- a/lib/qbwc/request/products.rb
+++ b/lib/qbwc/request/products.rb
@@ -68,17 +68,29 @@ module QBWC
             config = { connection_id: params['connection_id'] }.with_indifferent_access
             session_id = Persistence::Session.save(config, object)
 
-            request << search_xml(product_identifier(object), session_id)
+            if object['list_id'].to_s.empty?
+              request << search_xml_by_name(product_identifier(object), session_id)
+            else
+              request << search_xml_by_id(object['list_id'], session_id)
+            end
           end
         end
 
-        def search_xml(product_id, session_id)
+        def search_xml_by_id(object_id, session_id)
+          <<~XML
+            <ItemInventoryQueryRq requestID="#{session_id}">
+              <ListID>#{object_id}</ListID>
+            </ItemInventoryQueryRq>
+          XML
+        end
+
+        def search_xml_by_name(object_id, session_id)
           <<~XML
             <ItemInventoryQueryRq requestID="#{session_id}">
               <MaxReturned>10000</MaxReturned>
               <NameRangeFilter>
-                <FromName>#{product_id}</FromName>
-                <ToName>#{product_id}</ToName>
+                <FromName>#{object_id}</FromName>
+                <ToName>#{object_id}</ToName>
               </NameRangeFilter>
             </ItemInventoryQueryRq>
           XML

--- a/lib/qbwc/request/salestaxproducts.rb
+++ b/lib/qbwc/request/salestaxproducts.rb
@@ -30,17 +30,29 @@ module QBWC
             config = { connection_id: params['connection_id'] }.with_indifferent_access
             session_id = Persistence::Session.save(config, object)
 
-            request << search_xml(product_identifier(object), session_id)
+            if object['list_id'].to_s.empty?
+              request << search_xml_by_name(product_identifier(object), session_id)
+            else
+              request << search_xml_by_id(object['list_id'], session_id)
+            end
           end
         end
 
-        def search_xml(product_id, session_id)
+        def search_xml_by_id(object_id, session_id)
+          <<~XML
+            <ItemSalesTaxQueryRq requestID="#{session_id}">
+              <ListID>#{object_id}</ListID>
+            </ItemSalesTaxQueryRq>
+          XML
+        end
+
+        def search_xml_by_name(object_id, session_id)
           <<~XML
             <ItemSalesTaxQueryRq requestID="#{session_id}">
               <MaxReturned>10000</MaxReturned>
               <NameRangeFilter>
-                <FromName>#{product_id}</FromName>
-                <ToName>#{product_id}</ToName>
+                <FromName>#{object_id}</FromName>
+                <ToName>#{object_id}</ToName>
               </NameRangeFilter>
             </ItemSalesTaxQueryRq>
           XML

--- a/lib/qbwc/request/serviceproducts.rb
+++ b/lib/qbwc/request/serviceproducts.rb
@@ -53,17 +53,29 @@ module QBWC
             config = { connection_id: params['connection_id'] }.with_indifferent_access
             session_id = Persistence::Session.save(config, object)
 
-            request << search_xml(product_identifier(object), session_id)
+            if object['list_id'].to_s.empty?
+              request << search_xml_by_name(product_identifier(object), session_id)
+            else
+              request << search_xml_by_id(object['list_id'], session_id)
+            end
           end
         end
 
-        def search_xml(product_id, session_id)
+        def search_xml_by_id(object_id, session_id)
+          <<~XML
+            <ItemServiceQueryRq requestID="#{session_id}">
+              <ListID>#{object_id}</ListID>
+            </ItemServiceQueryRq>
+          XML
+        end
+
+        def search_xml_by_name(object_id, session_id)
           <<~XML
             <ItemServiceQueryRq requestID="#{session_id}">
               <MaxReturned>10000</MaxReturned>
               <NameRangeFilter>
-                <FromName>#{product_id}</FromName>
-                <ToName>#{product_id}</ToName>
+                <FromName>#{object_id}</FromName>
+                <ToName>#{object_id}</ToName>
               </NameRangeFilter>
             </ItemServiceQueryRq>
           XML

--- a/spec/qbwc/request/customer_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/customer_fixtures/add_update_search_xml_fixtures.rb
@@ -3,8 +3,8 @@ def qbe_customer_search_name
     <CustomerQueryRq requestID="12345">
       <MaxReturned>50</MaxReturned>
       <NameRangeFilter>
-        <FromName>My ID</FromName>
-        <ToName>My ID</ToName>
+        <FromName>Bruce Wayne</FromName>
+        <ToName>Bruce Wayne</ToName>
       </NameRangeFilter>
     </CustomerQueryRq>
   XML
@@ -13,7 +13,7 @@ end
 def qbe_customer_search_id
   <<~XML
     <CustomerQueryRq requestID="12345">
-      <ListID>My ID</ListID>
+      <ListID>qbe-customer-listid</ListID>
     </CustomerQueryRq>
   XML
 end
@@ -32,7 +32,7 @@ def qbe_customer_update
   <<~XML
     <CustomerModRq requestID="12345">
       <CustomerMod>
-        <ListID>12345</ListID>
+        <ListID>qbe-customer-listid</ListID>
         <EditSequence>1010101</EditSequence>
         #{qbe_customer_innards(true)}
       </CustomerMod>

--- a/spec/qbwc/request/customer_fixtures/customer_from_flowlink.json
+++ b/spec/qbwc/request/customer_fixtures/customer_from_flowlink.json
@@ -1,6 +1,6 @@
 {
   "id": 12345,
-  "list_id": 12345,
+  "list_id": "qbe-customer-listid",
   "edit_sequence": 1010101,
   "name": "First Last",
   "firstname": "First",

--- a/spec/qbwc/request/customers_spec.rb
+++ b/spec/qbwc/request/customers_spec.rb
@@ -4,7 +4,7 @@ require 'qbwc/request/customers'
 require 'qbwc/request/customer_fixtures/add_update_search_xml_fixtures'
 
 RSpec.describe QBWC::Request::Customers do
-  let(:flowlink_customer) { JSON.parse(File.read('spec/fixtures/customer_from_flowlink.json')) }
+  let(:flowlink_customer) { JSON.parse(File.read('spec/qbwc/request/customer_fixtures/customer_from_flowlink.json')) }
   let(:config) {
     {
       job_type_name: 'job_type_reference',
@@ -15,22 +15,39 @@ RSpec.describe QBWC::Request::Customers do
 
   it 'calls add_xml_to_send and outputs the right data' do
     customer = QBWC::Request::Customers.add_xml_to_send(flowlink_customer, 12345, config)
-    expect(customer.gsub(/\s+/, ')).to eq(qbe_customer_add.gsub(/\s+/, '))
+    expect(customer.gsub(/\s+/, "")).to eq(qbe_customer_add.gsub(/\s+/, ""))
   end
 
   it 'calls update_xml_to_send and outputs the right data' do
     customer = QBWC::Request::Customers.update_xml_to_send(flowlink_customer, 12345, config)
-    expect(customer.gsub(/\s+/, ')).to eq(qbe_customer_update.gsub(/\s+/, '))
+    expect(customer.gsub(/\s+/, "")).to eq(qbe_customer_update.gsub(/\s+/, ""))
   end
 
-  it 'calls search_xml_by_id and outputs the right data' do
-    customer = QBWC::Request::Customers.search_xml_by_id('My ID', 12345)
-    expect(customer.gsub(/\s+/, ')).to eq(qbe_customer_search_id.gsub(/\s+/, '))
-  end
+  describe "search xml" do
+    it "has list_id and calls search_xml_by_id" do
+      # Call search_xml method with flowlink_customer
+      pending("expect the search_xml_by_id method to have been called")
+      pending("expect the search_xml_by_name method to NOT have been called")
+      this_should_not_get_executed
+    end
 
-  it 'calls search_xml_by_name and outputs the right data' do
-    customer = QBWC::Request::Customers.search_xml_by_name('My ID', 12345)
-    expect(customer.gsub(/\s+/, ')).to eq(qbe_customer_search_name.gsub(/\s+/, '))
+    it "does not have list_id and calls search_xml_by_name" do
+      flowlink_customer.delete(:list_id)
+      # Call search_xml method with flowlink_customer
+      pending("expect the search_xml_by_name method to have been called")
+      pending("expect the search_xml_by_id method to NOT have been called")
+      this_should_not_get_executed
+    end
+
+    it 'calls search_xml_by_id and outputs the right data' do
+      customer = QBWC::Request::Customers.search_xml_by_id('qbe-customer-listid', 12345)
+      expect(customer.gsub(/\s+/, "")).to eq(qbe_customer_search_id.gsub(/\s+/, ""))
+    end
+  
+    it 'calls search_xml_by_name and outputs the right data' do
+      customer = QBWC::Request::Customers.search_xml_by_name('Bruce Wayne', 12345)
+      expect(customer.gsub(/\s+/, "")).to eq(qbe_customer_search_name.gsub(/\s+/, ""))
+    end
   end
 
   describe 'calls pre_mapping_logic' do

--- a/spec/qbwc/request/discountproduct_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/discountproduct_fixtures/add_update_search_xml_fixtures.rb
@@ -1,7 +1,7 @@
 def qbe_discountproduct_search_name
   <<~XML
     <ItemDiscountQueryRq requestID="12345">
-      <MaxReturned>50</MaxReturned>
+      <MaxReturned>10000</MaxReturned>
       <NameRangeFilter>
         <FromName>My Awesome Product</FromName>
         <ToName>My Awesome Product</ToName>

--- a/spec/qbwc/request/discountproduct_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/discountproduct_fixtures/add_update_search_xml_fixtures.rb
@@ -1,11 +1,19 @@
 def qbe_discountproduct_search_name
   <<~XML
     <ItemDiscountQueryRq requestID="12345">
-      <MaxReturned>10000</MaxReturned>
+      <MaxReturned>50</MaxReturned>
       <NameRangeFilter>
         <FromName>My Awesome Product</FromName>
         <ToName>My Awesome Product</ToName>
       </NameRangeFilter>
+    </ItemDiscountQueryRq>
+  XML
+end
+
+def qbe_discountproduct_search_id
+  <<~XML
+    <ItemDiscountQueryRq requestID="12345">
+      <ListID>test discount listid</ListID>
     </ItemDiscountQueryRq>
   XML
 end

--- a/spec/qbwc/request/discountproduct_spec.rb
+++ b/spec/qbwc/request/discountproduct_spec.rb
@@ -40,9 +40,28 @@ RSpec.describe QBWC::Request::Discountproducts do
     end
   end
 
-  describe "search xml by name" do
-    it "matches expected xml output" do
-      product = QBWC::Request::Discountproducts.search_xml("My Awesome Product", 12345)
+  describe "search xml" do
+    let(:flowlink_product) { JSON.parse(File.read('spec/qbwc/request/discountproduct_fixtures/discountproduct_from_flowlink.json')) }
+    it "has list_id and calls search_xml_by_id" do
+      flowlink_product[:list_id] = "test discount listid"
+
+      # Call search_xml method with flowlink_product
+      pending("expect the search_xml_by_id method to have been called")
+      pending("expect the search_xml_by_name method to NOT have been called")
+      this_should_not_get_executed
+    end
+    it "does not have list_id and calls search_xml_by_name" do
+      # Call search_xml method with flowlink_product
+      pending("expect the search_xml_by_name method to have been called")
+      pending("expect the search_xml_by_id method to NOT have been called")
+      this_should_not_get_executed
+    end
+    it "calls search_xml_by_id and matches expected xml output" do
+      product = QBWC::Request::Discountproducts.search_xml_by_id("test discount listid", 12345)
+      expect(product.gsub(/\s+/, "")).to eq(qbe_discountproduct_search_id.gsub(/\s+/, ""))
+    end
+    it "calls search_xml_by_name and matches expected xml output" do
+      product = QBWC::Request::Discountproducts.search_xml_by_name("My Awesome Product", 12345)
       expect(product.gsub(/\s+/, "")).to eq(qbe_discountproduct_search_name.gsub(/\s+/, ""))
     end
   end

--- a/spec/qbwc/request/noninventoryproduct_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/noninventoryproduct_fixtures/add_update_search_xml_fixtures.rb
@@ -10,6 +10,14 @@ def qbe_noninventoryproduct_search_name
   XML
 end
 
+def qbe_noninventoryproduct_search_id
+  <<~XML
+    <ItemNonInventoryQueryRq requestID="12345">
+      <ListID>test noninv listid</ListID>
+    </ItemNonInventoryQueryRq>
+  XML
+end
+
 def add_xml_sandp_noninventoryproduct
   <<~XML
     <ItemNonInventoryAddRq requestID="12345">

--- a/spec/qbwc/request/noninventoryproduct_spec.rb
+++ b/spec/qbwc/request/noninventoryproduct_spec.rb
@@ -40,9 +40,27 @@ RSpec.describe QBWC::Request::Noninventoryproducts do
     end
   end
 
-  describe "search xml by name" do
-    it "matches expected xml output" do
-      product = QBWC::Request::Noninventoryproducts.search_xml("My Awesome Product", 12345)
+  describe "search xml" do
+    let(:flowlink_product) { JSON.parse(File.read('spec/qbwc/request/noninventoryproduct_fixtures/noninvproduct_from_flowlink.json')) }
+    it "has list_id and calls search_xml_by_id" do
+      flowlink_product[:list_id] = "test discount listid"
+      # Call search_xml method with flowlink_product
+      pending("expect the search_xml_by_id method to have been called")
+      pending("expect the search_xml_by_name method to NOT have been called")
+      this_should_not_get_executed
+    end
+    it "does not have list_id and calls search_xml_by_name" do
+      # Call search_xml method with flowlink_product
+      pending("expect the search_xml_by_name method to have been called")
+      pending("expect the search_xml_by_id method to NOT have been called")
+      this_should_not_get_executed
+    end
+    it "calls search_xml_by_id and matches expected xml output" do
+      product = QBWC::Request::Noninventoryproducts.search_xml_by_id("test noninv listid", 12345)
+      expect(product.gsub(/\s+/, "")).to eq(qbe_noninventoryproduct_search_id.gsub(/\s+/, ""))
+    end
+    it "calls search_xml_by_name and matches expected xml output" do
+      product = QBWC::Request::Noninventoryproducts.search_xml_by_name("My Awesome Product", 12345)
       expect(product.gsub(/\s+/, "")).to eq(qbe_noninventoryproduct_search_name.gsub(/\s+/, ""))
     end
   end

--- a/spec/qbwc/request/noninventoryproduct_spec.rb
+++ b/spec/qbwc/request/noninventoryproduct_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe QBWC::Request::Noninventoryproducts do
   describe "search xml" do
     let(:flowlink_product) { JSON.parse(File.read('spec/qbwc/request/noninventoryproduct_fixtures/noninvproduct_from_flowlink.json')) }
     it "has list_id and calls search_xml_by_id" do
-      flowlink_product[:list_id] = "test discount listid"
+      flowlink_product[:list_id] = "test noninv listid"
       # Call search_xml method with flowlink_product
       pending("expect the search_xml_by_id method to have been called")
       pending("expect the search_xml_by_name method to NOT have been called")

--- a/spec/qbwc/request/product_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/product_fixtures/add_update_search_xml_fixtures.rb
@@ -1,3 +1,23 @@
+def qbe_product_search_name
+  <<~XML
+    <ItemInventoryQueryRq requestID="12345">
+      <MaxReturned>10000</MaxReturned>
+      <NameRangeFilter>
+        <FromName>My Awesome Product</FromName>
+        <ToName>My Awesome Product</ToName>
+      </NameRangeFilter>
+    </ItemInventoryQueryRq>
+  XML
+end
+
+def qbe_product_search_id
+  <<~XML
+    <ItemInventoryQueryRq requestID="12345">
+      <ListID>test product listid</ListID>
+    </ItemInventoryQueryRq>
+  XML
+end
+
 def add_xml
   <<~XML
     <ItemInventoryAddRq requestID="12345">

--- a/spec/qbwc/request/product_spec.rb
+++ b/spec/qbwc/request/product_spec.rb
@@ -4,7 +4,7 @@ require 'json'
 require "active_support/core_ext/hash/indifferent_access"
 require 'qbwc/request/vendors'
 require 'qbwc/request/product_fixtures/build_polling_from_config_fixtures'
-require 'qbwc/request/product_fixtures/add_and_update_xml_fixtures'
+require 'qbwc/request/product_fixtures/add_update_search_xml_fixtures'
 
 module QBWC
   module Request
@@ -78,6 +78,32 @@ RSpec.describe QBWC::Request::Products do
     it "it matches expected output" do
       product = QBWC::Request::Products.update_xml_to_send(flowlink_product, nil, 12345, config)
       expect(product.gsub(/\s+/, "")).to eq(update_xml.gsub(/\s+/, ""))
+    end
+  end
+
+  describe "search xml" do
+    let(:flowlink_product) { JSON.parse(File.read('spec/qbwc/request/product_fixtures/invproduct_from_flowlink.json')) }
+    it "has list_id and calls search_xml_by_id" do
+      flowlink_product[:list_id] = "test discount listid"
+
+      # Call search_xml method with flowlink_product
+      pending("expect the search_xml_by_id method to have been called")
+      pending("expect the search_xml_by_name method to NOT have been called")
+      this_should_not_get_executed
+    end
+    it "does not have list_id and calls search_xml_by_name" do
+      # Call search_xml method with flowlink_product
+      pending("expect the search_xml_by_name method to have been called")
+      pending("expect the search_xml_by_id method to NOT have been called")
+      this_should_not_get_executed
+    end
+    it "calls search_xml_by_id and matches expected xml output" do
+      product = QBWC::Request::Products.search_xml_by_id("test product listid", 12345)
+      expect(product.gsub(/\s+/, "")).to eq(qbe_product_search_id.gsub(/\s+/, ""))
+    end
+    it "calls search_xml_by_name and matches expected xml output" do
+      product = QBWC::Request::Products.search_xml_by_name("My Awesome Product", 12345)
+      expect(product.gsub(/\s+/, "")).to eq(qbe_product_search_name.gsub(/\s+/, ""))
     end
   end
 end

--- a/spec/qbwc/request/product_spec.rb
+++ b/spec/qbwc/request/product_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe QBWC::Request::Products do
   describe "search xml" do
     let(:flowlink_product) { JSON.parse(File.read('spec/qbwc/request/product_fixtures/invproduct_from_flowlink.json')) }
     it "has list_id and calls search_xml_by_id" do
-      flowlink_product[:list_id] = "test discount listid"
+      flowlink_product[:list_id] = "test product listid"
 
       # Call search_xml method with flowlink_product
       pending("expect the search_xml_by_id method to have been called")

--- a/spec/qbwc/request/salestaxproduct_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/salestaxproduct_fixtures/add_update_search_xml_fixtures.rb
@@ -10,6 +10,14 @@ def qbe_salestaxproduct_search_name
   XML
 end
 
+def qbe_salestaxproduct_search_id
+  <<~XML
+    <ItemSalesTaxQueryRq requestID="12345">
+      <ListID>test salestax listid</ListID>
+    </ItemSalesTaxQueryRq>
+  XML
+end
+
 def add_xml_salestaxproduct
   <<~XML
     <ItemSalesTaxAddRq requestID="12345">

--- a/spec/qbwc/request/salestaxproduct_spec.rb
+++ b/spec/qbwc/request/salestaxproduct_spec.rb
@@ -40,9 +40,28 @@ RSpec.describe QBWC::Request::Salestaxproducts do
     end
   end
 
-  describe "search xml by name" do
-    it "matches expected xml output" do
-      product = QBWC::Request::Salestaxproducts.search_xml("My Awesome Product", 12345)
+  describe "search xml" do
+    let(:flowlink_product) { JSON.parse(File.read('spec/qbwc/request/product_fixtures/invproduct_from_flowlink.json')) }
+    it "has list_id and calls search_xml_by_id" do
+      flowlink_product[:list_id] = "test salestax listid"
+
+      # Call search_xml method with flowlink_product
+      pending("expect the search_xml_by_id method to have been called")
+      pending("expect the search_xml_by_name method to NOT have been called")
+      this_should_not_get_executed
+    end
+    it "does not have list_id and calls search_xml_by_name" do
+      # Call search_xml method with flowlink_product
+      pending("expect the search_xml_by_name method to have been called")
+      pending("expect the search_xml_by_id method to NOT have been called")
+      this_should_not_get_executed
+    end
+    it "calls search_xml_by_id and matches expected xml output" do
+      product = QBWC::Request::Salestaxproducts.search_xml_by_id("test salestax listid", 12345)
+      expect(product.gsub(/\s+/, "")).to eq(qbe_salestaxproduct_search_id.gsub(/\s+/, ""))
+    end
+    it "calls search_xml_by_name and matches expected xml output" do
+      product = QBWC::Request::Salestaxproducts.search_xml_by_name("My Awesome Product", 12345)
       expect(product.gsub(/\s+/, "")).to eq(qbe_salestaxproduct_search_name.gsub(/\s+/, ""))
     end
   end

--- a/spec/qbwc/request/serviceproduct_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/serviceproduct_fixtures/add_update_search_xml_fixtures.rb
@@ -10,6 +10,16 @@ def qbe_serviceproduct_search_name
   XML
 end
 
+def qbe_serviceproduct_search_id
+  <<~XML
+    <ItemServiceQueryRq requestID="12345">
+      <ListID>test service listid</ListID>
+    </ItemServiceQueryRq>
+  XML
+end
+
+
+
 def add_xml_sandp_serviceproduct
   <<~XML
     <ItemServiceAddRq requestID="12345">

--- a/spec/qbwc/request/serviceproduct_spec.rb
+++ b/spec/qbwc/request/serviceproduct_spec.rb
@@ -40,9 +40,28 @@ RSpec.describe QBWC::Request::Serviceproducts do
     end
   end
 
-  describe "search xml by name" do
-    it "matches expected xml output" do
-      product = QBWC::Request::Serviceproducts.search_xml("My Awesome Product", 12345)
+  describe "search xml" do
+    let(:flowlink_product) { JSON.parse(File.read('spec/qbwc/request/serviceproduct_fixtures/serviceproduct_from_flowlink.json')) }
+    it "has list_id and calls search_xml_by_id" do
+      flowlink_product[:list_id] = "test service listid"
+
+      # Call search_xml method with flowlink_product
+      pending("expect the search_xml_by_id method to have been called")
+      pending("expect the search_xml_by_name method to NOT have been called")
+      this_should_not_get_executed
+    end
+    it "does not have list_id and calls search_xml_by_name" do
+      # Call search_xml method with flowlink_product
+      pending("expect the search_xml_by_name method to have been called")
+      pending("expect the search_xml_by_id method to NOT have been called")
+      this_should_not_get_executed
+    end
+    it "calls search_xml_by_id and matches expected xml output" do
+      product = QBWC::Request::Serviceproducts.search_xml_by_id("test service listid", 12345)
+      expect(product.gsub(/\s+/, "")).to eq(qbe_serviceproduct_search_id.gsub(/\s+/, ""))
+    end
+    it "calls search_xml_by_name and matches expected xml output" do
+      product = QBWC::Request::Serviceproducts.search_xml_by_name("My Awesome Product", 12345)
       expect(product.gsub(/\s+/, "")).to eq(qbe_serviceproduct_search_name.gsub(/\s+/, ""))
     end
   end

--- a/spec/qbwc/request/vendor_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/vendor_fixtures/add_update_search_xml_fixtures.rb
@@ -13,7 +13,7 @@ end
 def qbe_vendor_search_id
   <<~XML
     <VendorQueryRq requestID="12345">
-      <ListID>My ID</ListID>
+      <ListID>qbe-vendor-listid</ListID>
     </VendorQueryRq>
   XML
 end
@@ -32,7 +32,7 @@ def qbe_vendor_update
   <<~XML
     <VendorModRq requestID="12345">
       <VendorMod>
-        <ListID>12345</ListID>
+        <ListID>qbe-vendor-listid</ListID>
         <EditSequence>1010101</EditSequence>
         #{qbe_vendor_innards(true)}
       </VendorMod>

--- a/spec/qbwc/request/vendor_fixtures/vendor_from_flowlink.json
+++ b/spec/qbwc/request/vendor_fixtures/vendor_from_flowlink.json
@@ -1,6 +1,6 @@
 {
   "id": 12345,
-  "list_id": 12345,
+  "list_id": "qbe-vendor-listid",
   "edit_sequence": 1010101,
   "name": "First Last",
   "firstname": "First",

--- a/spec/qbwc/request/vendors_spec.rb
+++ b/spec/qbwc/request/vendors_spec.rb
@@ -4,7 +4,7 @@ require 'qbwc/request/vendors'
 require 'qbwc/request/vendor_fixtures/add_update_search_xml_fixtures'
 
 RSpec.describe QBWC::Request::Vendors do
-  let(:flowlink_vendor) { JSON.parse(File.read('spec/fixtures/vendor_from_flowlink.json')) }
+  let(:flowlink_vendor) { JSON.parse(File.read('spec/qbwc/request/vendor_fixtures/vendor_from_flowlink.json')) }
   let(:config) {
     {
       job_type_name: "job_type_reference",
@@ -23,14 +23,31 @@ RSpec.describe QBWC::Request::Vendors do
     expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_update.gsub(/\s+/, ""))
   end
 
-  it "calls search_xml_by_id and outputs the right data" do
-    vendor = described_class.search_xml_by_id("My ID", 12345)
-    expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_search_id.gsub(/\s+/, ""))
-  end
+  describe "search xml" do
+    it "has list_id and calls search_xml_by_id" do
+      # Call search_xml method with flowlink_customer
+      pending("expect the search_xml_by_id method to have been called")
+      pending("expect the search_xml_by_name method to NOT have been called")
+      this_should_not_get_executed
+    end
 
-  it "calls search_xml_by_name and outputs the right data" do
-    vendor = described_class.search_xml_by_name("My ID", 12345)
-    expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_search_name.gsub(/\s+/, ""))
+    it "does not have list_id and calls search_xml_by_name" do
+      flowlink_vendor.delete(:list_id)
+      # Call search_xml method with flowlink_customer
+      pending("expect the search_xml_by_name method to have been called")
+      pending("expect the search_xml_by_id method to NOT have been called")
+      this_should_not_get_executed
+    end
+
+    it "calls search_xml_by_id and outputs the right data" do
+      vendor = described_class.search_xml_by_id("qbe-vendor-listid", 12345)
+      expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_search_id.gsub(/\s+/, ""))
+    end
+  
+    it "calls search_xml_by_name and outputs the right data" do
+      vendor = described_class.search_xml_by_name("My ID", 12345)
+      expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_search_name.gsub(/\s+/, ""))
+    end
   end
 
   describe 'calls pre_mapping_logic' do


### PR DESCRIPTION
We need to be able to search by Name and by ListID for these objects in case Name field is one of the fields being updated:
- Service products
- Salestax products
- Discount products
- Inventory Products products
- NonInventory Products products
- Customers
- Vendors

We might need it for Invoices/Sales Receipts/Sales Orders/POs too maybe? But not in this PR.