### PR TITLE
Update bucket name to `qbe-staging` and add cloudbuild line

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,3 +5,5 @@ steps:
   args: ['push', 'gcr.io/flowlink-project/github.com/flowlink/${_DOCKERTAG}:${SHORT_SHA}']
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ['beta', 'run', 'deploy', '${_CRNAME}', '--image', 'gcr.io/flowlink-project/github.com/flowlink/${_DOCKERTAG}:${SHORT_SHA}', '--region', 'us-central1', '--platform', 'managed', '--allow-unauthenticated']
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: ['beta', 'run', 'services', 'update-traffic', 'quickbooksdesktopintegrationdev', '--region', 'us-central1', '--platform', 'managed', '--to-latest']

--- a/lib/persistence/path.rb
+++ b/lib/persistence/path.rb
@@ -8,7 +8,7 @@ module Persistence
     end
 
     def bucket_name
-      'quickbooks-desktop-integration'
+      'qbe-staging'
     end
 
     def two_phase_pending


### PR DESCRIPTION
- The bucket for staging would be a separate one from the one used in
the integrations server
- Added a line in cloud build to use the latest revision. I manually
changed the traffic while debugging and broke the automatic setting
towards the newest revision