### PR TITLE
Removed ability to grab other product types from request/products.rb.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,20 @@
 This is a fully hosted and supported integration for use with the [FlowLink](http://flowlink.io/)
 product. With this integration you can perform the following functions:
 
-* Send orders to Quickbooks
+* Send/Receive orders to Quickbooks
+* Send/Receive invoices to Quickbooks
+* Send/Receive sales receipts to Quickbooks
+* Send/Receive customers to Quickbooks
+* Send/Receive vendors to Quickbooks
+* Send/Receives products (Inventory, NonInventory, Service, Discount, Sales Tax types) to Quickbooks
+* Receives Inventory Assembly product types from Quickbooks
+* Send/Receive purchase orders to Quickbooks
+* Send payments to Quickbooks
+* Send journal entries to Quickbooks
 * Send returns to Quickbooks
 * Send shipments to Quickbooks
-* Send customers to Quickbooks
-* Send/Receives products to Quickbooks
 * Set/Receives inventories to Quicbooks
+* Receives inventories by site from Quicbooks
 
 ## Connection Parameters
 
@@ -27,14 +35,37 @@ The following parameters must be setup within [Flowlink](http://flowlink.io):
 
 The following webhooks are implemented:
 
-* **add_orders**: Adds orders to QuickBooks
+* **add_orders**: Adds and Updates sales orders in QuickBooks
+* **add_invoices**: Adds and Updates invoices in QuickBooks
+* **add_salesreceipts**: Adds and Updates sales receipts in QuickBooks
+* **add_customers**: Adds and Updates customers in QuickBooks
+* **add_vendors**: Adds and Updates vendors in QuickBooks
+* **add_products**: Adds and Updates products of type Inventory in QuickBooks
+* **add_noninventoryproducts**: Adds and Updates products of type NonInventory in QuickBooks
+* **add_serviceproducts**: Adds and Updates products of type Service in QuickBooks
+* **add_discountproducts**: Adds and Updates products of type Discount in QuickBooks
+* **add_salestaxproducts**: Adds and Updates products of type SalesTax in QuickBooks
+* **add_purchaseorders**: Adds and Updates purchase orders in QuickBooks
+* **add_payments**: Adds payments to QuickBooks
+* **add_journals**: Adds and Updates journal entries in QuickBooks
+* **add_inventories**: Adds inventories to QuickBooks
 * **add_returns**: Adds returns to QuickBooks
 * **add_shipments**: Adds shipments to QuickBooks
-* **add_customers**: Adds customers to QuickBooks
-* **add_products**: Adds products to QuickBooks
-* **add_inventories**: Adds inventories to QuickBooks
-* **get_products**: Gets products from QuickBooks
+
+* **get_orders**: Gets orders from QuickBooks
+* **get_invoices**: Gets invoices from QuickBooks
+* **get_customers**: Gets customers from QuickBooks
+* **get_vendors**: Gets vendors from QuickBooks
+* **get_products**: Gets products of type Inventory from QuickBooks
+* **get_inventoryproducts**: Gets products of type Inventory from QuickBooks
+* **get_noninventoryproducts**: Gets products of type NonInventory from QuickBooks
+* **get_serviceproducts**: Gets products of type Service from QuickBooks
+* **get_discountproducts**: Gets products of type Discount from QuickBooks
+* **get_salestaxproducts**: Gets products of type SalesTax from QuickBooks
+* **get_inventoryassemblyproducts**: Gets products of type InventoryAssembly from QuickBooks
+* **get_purchaseorders**: Gets purchase orders from QuickBooks
 * **get_inventories**: Gets inventories from QuickBooks
+* **get_inventorywithsites**: Gets inventories by Site from QuickBooks
 
 ### add_orders
 
@@ -74,32 +105,14 @@ The following parameters are required when setting up a Flow with this webhook:
 
 ### Getting Products
 
-You can retrieve products from QBE in a couple different ways.
-
 You can retrieve specific product types by calling any of the following endpoints:
 
+* /get_products (alias for /get_inventoryproducts)
 * /get_noninventoryproducts
 * /get_serviceproducts
 * /get_salestaxproducts
 * /get_discountproducts
-* /get_inventoryproducts
-
----
-
-You can also get all products by calling `/get_products` and it will return all possible types (inventory, non-inventory, assembly, service, sales tax, discount)
-
----
-
-You can also call `/get_products` and specify a config value - see below
-
-  ```ruby
-  # Accepted values in the array are shown below
-  # Non valid inputs will be ignored
-
-  config[:quickbooks_specify_products] = "[\"inventory\", \"assembly\", \"noninventory\", \"salestax\", \"service\", \"discount\"]"
-
-  # NOTE: Be sure to escape the string values of each item in the "array"
-```
+* /get_inventoryassemblyproducts
 
 ### Adding Products
 

--- a/lib/persistence/object.rb
+++ b/lib/persistence/object.rb
@@ -9,6 +9,7 @@ module Persistence
       inventoryproducts
       salestaxproducts
       serviceproducts
+      inventoryassemblyproducts
     )
 
     IDS_TO_LOG_S3_OBJ_MOVEMENT = ENV.fetch('IDS_TO_LOG', '').split(',')

--- a/lib/qbwc/request/inventoryassemblyproducts.rb
+++ b/lib/qbwc/request/inventoryassemblyproducts.rb
@@ -1,0 +1,85 @@
+module QBWC
+  module Request
+    class Inventoryassemblyproducts
+
+      class << self
+        def generate_request_insert_update(objects, params = {})
+          # We don't add/update assembly items in QBE
+          ""
+        end
+
+        def generate_request_queries(objects, params)
+          objects.inject('') do |request, object|
+            config = { connection_id: params['connection_id'] }.with_indifferent_access
+            session_id = Persistence::Session.save(config, object)
+
+            if object['list_id'].to_s.empty?
+              request << search_xml_by_name(product_identifier(object), session_id)
+            else
+              request << search_xml_by_id(object['list_id'], session_id)
+            end
+          end
+        end
+
+        def search_xml_by_id(object_id, session_id)
+          <<~XML
+            <ItemInventoryAssemblyQueryRq requestID="#{session_id}">
+              <ListID>#{object_id}</ListID>
+            </ItemInventoryAssemblyQueryRq>
+          XML
+        end
+
+        def search_xml_by_name(object_id, session_id)
+          <<~XML
+            <ItemInventoryAssemblyQueryRq requestID="#{session_id}">
+              <MaxReturned>10000</MaxReturned>
+              <NameRangeFilter>
+                <FromName>#{object_id}</FromName>
+                <ToName>#{object_id}</ToName>
+              </NameRangeFilter>
+            </ItemInventoryAssemblyQueryRq>
+          XML
+        end
+
+        def polling_others_items_xml(_timestamp, _config)
+          # nothing on this class
+          ''
+        end
+
+        def polling_current_items_xml(params, config)
+          timestamp = params['quickbooks_since']
+          session_id = Persistence::Session.save(config, 'polling' => timestamp)
+          time = Time.parse(timestamp).in_time_zone 'Pacific Time (US & Canada)'
+
+          inventory_max_returned = nil
+          inventory_max_returned = 10000 if params['return_all'].to_i == 1
+          if params['quickbooks_max_returned'] && params['quickbooks_max_returned'] != ""
+            inventory_max_returned = params['quickbooks_max_returned']
+          end
+
+          <<~XML
+            <!-- polling non inventory products -->
+            <ItemInventoryAssemblyQueryRq requestID="#{session_id}">
+              <MaxReturned>#{inventory_max_returned || 50}</MaxReturned>
+                #{query_by_date(params, time)}
+            </ItemInventoryAssemblyQueryRq>
+          XML
+        end
+
+        private
+
+        def product_identifier(object)
+          object['product_id'] || object['sku'] || object['id']
+        end
+
+        def query_by_date(config, time)
+          return '' if config['return_all'].to_i == 1
+
+          <<~XML
+            <FromModifiedDate>#{time.iso8601}</FromModifiedDate>
+          XML
+        end
+      end
+    end
+  end
+end

--- a/lib/qbwc/request/products.rb
+++ b/lib/qbwc/request/products.rb
@@ -143,10 +143,6 @@ module QBWC
           session_id = Persistence::Session.save(config, 'polling' => timestamp)
           time = Time.parse(timestamp).in_time_zone 'Pacific Time (US & Canada)'
 
-          if params['quickbooks_specify_products'] && params['quickbooks_specify_products'] != ""
-            return build_polling_from_config_param(params, session_id, time)
-          end
-
           inventory_max_returned = nil
           inventory_max_returned = 10000 if params['return_all'].to_i == 1
           if params['quickbooks_max_returned'] && params['quickbooks_max_returned'] != ""
@@ -158,26 +154,6 @@ module QBWC
               <MaxReturned>#{inventory_max_returned || 50}</MaxReturned>
               #{query_by_date(params, time)}
             </ItemInventoryQueryRq>
-            <ItemInventoryAssemblyQueryRq requestID="#{session_id}">
-              <MaxReturned>#{inventory_max_returned || 50}</MaxReturned>
-              #{query_by_date(params, time)}
-            </ItemInventoryAssemblyQueryRq>
-            <ItemNonInventoryQueryRq requestID="#{session_id}">
-              <MaxReturned>#{inventory_max_returned || 50}</MaxReturned>
-              #{query_by_date(params, time)}
-            </ItemNonInventoryQueryRq>
-            <ItemSalesTaxQueryRq requestID="#{session_id}">
-              <MaxReturned>#{inventory_max_returned || 50}</MaxReturned>
-              #{query_by_date(params, time)}
-            </ItemSalesTaxQueryRq>
-            <ItemServiceQueryRq requestID="#{session_id}">
-              <MaxReturned>#{inventory_max_returned || 50}</MaxReturned>
-              #{query_by_date(params, time)}
-            </ItemServiceQueryRq>
-            <ItemDiscountQueryRq requestID="#{session_id}">
-              <MaxReturned>#{inventory_max_returned || 50}</MaxReturned>
-              #{query_by_date(params, time)}
-            </ItemDiscountQueryRq>
           XML
         end
 
@@ -190,18 +166,6 @@ module QBWC
         end
 
         private
-
-        def build_polling_from_config_param(params, session_id, time)
-          JSON.parse(params['quickbooks_specify_products']).map do |value|
-            next unless PRODUCT_TYPES.has_key?(value.to_sym)
-            <<~XML
-              <#{PRODUCT_TYPES[value.to_sym]} requestID="#{session_id}">
-                <MaxReturned>50</MaxReturned>
-                #{query_by_date(params, time)}
-              </#{PRODUCT_TYPES[value.to_sym]}>
-            XML
-          end.join
-        end
 
         def product_identifier(object)
           object['product_id'] || object['sku'] || object['id']

--- a/lib/qbwc/response/item_discount_query_rs.rb
+++ b/lib/qbwc/response/item_discount_query_rs.rb
@@ -11,7 +11,7 @@ module QBWC
         errors.each do |error|
           Persistence::Object.handle_error(config,
                                            error.merge(context: 'Querying discount products'),
-                                           'products',
+                                           'discountproducts',
                                            error[:request_id])
         end
       end
@@ -23,7 +23,7 @@ module QBWC
         discountproduct_params = receive_configs.find { |c| c['discountproducts'] }
 
         if discountproduct_params
-          payload = { discountproducts: discountproducts_to_flowlink }
+          payload = { products: products_to_flowlink }
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == "origin"}
           poll_persistence = Persistence::Polling.new(config, payload)
           poll_persistence.save_for_polling
@@ -78,7 +78,7 @@ module QBWC
         end.join('') + object['Name']
       end
 
-      def discountproducts_to_flowlink
+      def products_to_flowlink
         records.map do |record|
           object = {
             id: record['Name'],

--- a/lib/qbwc/response/item_inventory_assembly_query_rs.rb
+++ b/lib/qbwc/response/item_inventory_assembly_query_rs.rb
@@ -11,7 +11,7 @@ module QBWC
         errors.each do |error|
           Persistence::Object.handle_error(config,
                                            error.merge(context: 'Querying assembled products'),
-                                           'products',
+                                           'inventoryassemblyproducts',
                                            error[:request_id])
         end
       end
@@ -21,7 +21,7 @@ module QBWC
 
         receive_configs = config[:receive] || []
         inventory_params = receive_configs.find { |c| c['inventories'] }
-        product_params = receive_configs.find { |c| c['products'] }
+        inventoryassemblyproduct_params = receive_configs.find { |c| c['inventoryassemblyproducts'] }
 
         if inventory_params
           payload = { inventories: inventories_to_flowlink }
@@ -31,18 +31,18 @@ module QBWC
           poll_persistence.save_for_polling
         end
 
-        if product_params
+        if inventoryassemblyproduct_params
           payload = { products: products_to_flowlink }
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == "origin"}
           poll_persistence = Persistence::Polling.new(config, payload)
           poll_persistence.save_for_polling
 
-          product_params['products']['quickbooks_since'] = last_time_modified
-          product_params['products']['quickbooks_force_config'] = 'true'
+          inventoryassemblyproduct_params['products']['quickbooks_since'] = last_time_modified
+          inventoryassemblyproduct_params['products']['quickbooks_force_config'] = 'true'
 
           # Override configs to update timestamp so it doesn't keep geting the
           # same inventories
-          params = product_params['products']
+          params = inventoryassemblyproduct_params['products']
           Persistence::Settings.new(params.with_indifferent_access).setup
         end
 
@@ -64,11 +64,27 @@ module QBWC
         records.map do |record|
           {
             object_type: 'product',
-            object_ref: (record['ParentRef'].is_a?(Array) ? record['ParentRef'] : (record['ParentRef'].nil? ? [] : [record['ParentRef']])).map { |item| item['FullName'] + ':' }.join('') + record['Name'],
+            object_ref: build_product_id_or_ref(record),
+            product_id: record['Name'],
             list_id: record['ListID'],
             edit_sequence: record['EditSequence']
           }
         end
+      end
+
+      def build_product_id_or_ref(object)
+        return object['Name'] if object['ParentRef'].nil?
+        
+        if object['ParentRef'].is_a?(Array)
+          arr = object['ParentRef']
+        else
+          arr = [object['ParentRef']]
+        end
+        
+        arr.map do |item|
+          next unless item['FullName']
+          "#{item['FullName']}:"
+        end.join('') + object['Name']
       end
 
       def inventories_to_flowlink

--- a/lib/qbwc/response/item_non_inventory_query_rs.rb
+++ b/lib/qbwc/response/item_non_inventory_query_rs.rb
@@ -23,7 +23,7 @@ module QBWC
         noninventoryproduct_params = receive_configs.find { |c| c['noninventoryproducts'] }
 
         if noninventoryproduct_params
-          payload = { noninventoryproducts: noninventoryproducts_to_flowlink }
+          payload = { products: products_to_flowlink }
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == "origin"}
           poll_persistence = Persistence::Polling.new(config, payload)
           poll_persistence.save_for_polling
@@ -78,7 +78,7 @@ module QBWC
         end.join('') + object['Name']
       end
 
-      def noninventoryproducts_to_flowlink
+      def products_to_flowlink
         records.map do |record|
           object = {
             id: record['Name'],

--- a/lib/qbwc/response/item_sales_tax_query_rs.rb
+++ b/lib/qbwc/response/item_sales_tax_query_rs.rb
@@ -11,7 +11,7 @@ module QBWC
         errors.each do |error|
           Persistence::Object.handle_error(config,
                                            error.merge(context: 'Querying sales tax products'),
-                                           'products',
+                                           'salestaxproducts',
                                            error[:request_id])
         end
       end
@@ -20,10 +20,11 @@ module QBWC
         return if records.empty?
 
         receive_configs = config[:receive] || []
+        puts({connection_id: config[:connection_id], method: "ItemSalesTaxQueryRs - process", receive_configs: receive_configs, records: records})
         salestaxproduct_params = receive_configs.find { |c| c['salestaxproducts'] }
 
         if salestaxproduct_params
-          payload = { salestaxproducts: salestaxproducts_to_flowlink }
+          payload = { products: products_to_flowlink }
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == "origin"}
           poll_persistence = Persistence::Polling.new(config, payload)
           poll_persistence.save_for_polling
@@ -78,7 +79,7 @@ module QBWC
         end.join('') + object['Name']
       end
 
-      def salestaxproducts_to_flowlink
+      def products_to_flowlink
         records.map do |record|
           object = {
             id: record['Name'],

--- a/lib/qbwc/response/item_service_query_rs.rb
+++ b/lib/qbwc/response/item_service_query_rs.rb
@@ -20,11 +20,11 @@ module QBWC
         return if records.empty?
 
         receive_configs = config[:receive] || []
-        puts({connection_id: config[:connection_id], method: "ItemServiceQueryRs - process", receive_configs: receive_configs})
+        puts({connection_id: config[:connection_id], method: "ItemServiceQueryRs - process", receive_configs: receive_configs, records: records})
         serviceproduct_params = receive_configs.find { |c| c['serviceproducts'] }
 
         if serviceproduct_params
-          payload = { serviceproducts: products_to_flowlink }
+          payload = { products: products_to_flowlink }
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == "origin"}
           poll_persistence = Persistence::Polling.new(config, payload)
           poll_persistence.save_for_polling

--- a/quickbooks_desktop_endpoint.rb
+++ b/quickbooks_desktop_endpoint.rb
@@ -37,6 +37,7 @@ GET_ENDPOINTS =  %w(
   get_salestaxproducts
   get_discountproducts
   get_inventoryproducts
+  get_inventoryassemblyproducts
 )
 
 class QuickbooksDesktopEndpoint < EndpointBase::Sinatra::Base

--- a/spec/qbwc/producer_spec.rb
+++ b/spec/qbwc/producer_spec.rb
@@ -184,57 +184,6 @@ module QBWC
         end
       end
 
-      describe 'noninventory params products' do
-        it 'only returns ItemNonInventoryQueryRq without since date' do
-          subject = described_class.new({connection_id: '54591b3a5869632afc090000'}, {})
-          since_date = "2020-03-01T06:39:43-08:00"
-          allow_any_instance_of(Persistence::Settings).to receive(:settings).and_return(
-            [
-              {
-                products: {
-                  "connection_id" => "nurelmremote",
-                  "quickbooks_since" => since_date,
-                  "flow" => "get_products",
-                  "origin" => "flowlink",
-                  "return_all" => "1",
-                  "quickbooks_force_config" => "1",
-                  "quickbooks_specify_products" => "[\"noninventory\"]"
-                }
-              }
-            ]
-          )
-
-          request = subject.build_polling_request
-          expect(request).to include('ItemNonInventoryQueryRq')
-          expect(request).not_to include('ItemInventoryQueryRq')
-          expect(request).not_to include(since_date)
-        end
-
-        it 'only returns ItemNonInventoryQueryRq and since date' do
-          subject = described_class.new({connection_id: '54591b3a5869632afc090000'}, {})
-          since_date = "2020-03-01T06:39:43-08:00"
-          allow_any_instance_of(Persistence::Settings).to receive(:settings).and_return(
-            [
-              {
-                products: {
-                  "connection_id" => "nurelmremote",
-                  "quickbooks_since" => since_date,
-                  "flow" => "get_products",
-                  "origin" => "flowlink",
-                  "quickbooks_force_config" => "1",
-                  "quickbooks_specify_products" => "[\"noninventory\"]"
-                }
-              }
-            ]
-          )
-
-          request = subject.build_polling_request
-          expect(request).to include('ItemNonInventoryQueryRq')
-          expect(request).not_to include('ItemInventoryQueryRq')
-          expect(request).to include(since_date)
-        end
-      end
-
       describe '/get_vendors' do
         it 'uses given since-date in query' do
           subject = described_class.new({connection_id: '54591b3a5869632afc090000'}, {})

--- a/spec/qbwc/request/product_spec.rb
+++ b/spec/qbwc/request/product_spec.rb
@@ -42,30 +42,6 @@ module QBWC
 end
 
 RSpec.describe QBWC::Request::Products do
-  describe "calls build_polling_from_config_param" do
-    config = {since: "2020-03-30 14:25:13 -0400"}.with_indifferent_access
-    time = Time.parse(config[:since]).in_time_zone 'Pacific Time (US & Canada)'
-    session_id = "12345903"
-    
-    it "it matches expected output when given full list of params" do
-      config[:quickbooks_specify_products] = "[\"inventory\", \"assembly\", \"noninventory\", \"salestax\", \"service\", \"discount\"]"
-      response = QBWC::Request::Products.send(:build_polling_from_config_param, config, session_id, time)
-      expect(response.delete!("\n")).to eq(full_expected_output(time).delete!("\n"))
-    end
-
-    it "it matches expected output when given partial list of params" do
-      config[:quickbooks_specify_products] = "[\"inventory\",  \"salestax\", \"service\"]"
-      response = QBWC::Request::Products.send(:build_polling_from_config_param, config, session_id, time)
-      expect(response.delete!("\n")).to eq(partial_expected_output(time).delete!("\n"))
-    end
-
-    it "it matches expected output when given 1 param" do
-      config[:quickbooks_specify_products] = "[\"service\"]"
-      response = QBWC::Request::Products.send(:build_polling_from_config_param, config, session_id, time)
-      expect(response.delete!("\n")).to eq(one_expected_output(time).delete!("\n"))
-    end
-  end
-
   describe "builds xml for adding or updating" do
     let(:flowlink_product) { JSON.parse(File.read('spec/qbwc/request/product_fixtures/invproduct_from_flowlink.json')) }
     config = {quickbooks_cogs_account: "Cost of Goods"}

--- a/spec/qbwc/response/item_non_inventory_query_rs_spec.rb
+++ b/spec/qbwc/response/item_non_inventory_query_rs_spec.rb
@@ -4,7 +4,7 @@ require "active_support/core_ext/hash/indifferent_access"
 require 'qbwc/response/item_non_inventory_query_rs'
 
 RSpec.describe QBWC::Response::ItemNonInventoryQueryRs do
-  describe "calls noninventoryproducts_to_flowlink" do
+  describe "calls products_to_flowlink" do
     let(:sandp_qbe_product) { JSON.parse(File.read('spec/qbwc/response/noninventory_product_fixtures/sales_and_purchase_prod_from_qbe.json')) }
     let(:sorp_qbe_product) { JSON.parse(File.read('spec/qbwc/response/noninventory_product_fixtures/sales_or_purchase_prod_from_qbe.json')) }
     
@@ -17,7 +17,7 @@ RSpec.describe QBWC::Response::ItemNonInventoryQueryRs do
       expected_product = base_flowlink_product.merge(fl_sales_and_purchase).compact
 
       non_inv_rs = QBWC::Response::ItemNonInventoryQueryRs.new([sandp_qbe_product])
-      output = non_inv_rs.send(:noninventoryproducts_to_flowlink).first.with_indifferent_access
+      output = non_inv_rs.send(:products_to_flowlink).first.with_indifferent_access
 
       expect(output).to eq(expected_product.with_indifferent_access)
     end
@@ -28,7 +28,7 @@ RSpec.describe QBWC::Response::ItemNonInventoryQueryRs do
         
         sorp_qbe_product["SalesOrPurchase"]["Price"] = 100
         non_inv_rs = QBWC::Response::ItemNonInventoryQueryRs.new([sorp_qbe_product])
-        output = non_inv_rs.send(:noninventoryproducts_to_flowlink).first.with_indifferent_access
+        output = non_inv_rs.send(:products_to_flowlink).first.with_indifferent_access
 
         expect(output).to eq(expected_product.with_indifferent_access)
       end
@@ -38,7 +38,7 @@ RSpec.describe QBWC::Response::ItemNonInventoryQueryRs do
 
         sorp_qbe_product["SalesOrPurchase"]["PricePercent"] = 100
         non_inv_rs = QBWC::Response::ItemNonInventoryQueryRs.new([sorp_qbe_product])
-        output = non_inv_rs.send(:noninventoryproducts_to_flowlink).first.with_indifferent_access
+        output = non_inv_rs.send(:products_to_flowlink).first.with_indifferent_access
 
         puts expected_product
 


### PR DESCRIPTION
- Removed ability to grab other product types from request/products.rb.
- Removed tests that are no longer needed.
- Updated readme.
- Updated other item type _rs classes to use correct config value and product key for final send to FL
