### PR TITLE
Add a timestamp field to the inventories returned

### DIFF
--- a/lib/qbwc/response/item_site_query_rs.rb
+++ b/lib/qbwc/response/item_site_query_rs.rb
@@ -60,7 +60,8 @@ module QBWC
             quantity_on_sales_order: record['QuantityOnSalesOrders'],
             quantity_to_be_assembled: record['QuantityToBeBuiltByPendingBuildTxns'],
             quantity_by_being_assembled: record['QuantityRequiredByPendingBuildTxns'],
-            quantity_by_pending_transfer: record['QuantityOnPendingTransfers']
+            quantity_by_pending_transfer: record['QuantityOnPendingTransfers'],
+            timestamp: Time.now.to_s
           }
         end
       end


### PR DESCRIPTION
- This forces the Flowlink to see it as updated each time it's returned
from QuickBooks