### PR TITLE
Create `#save_for_polling_without_timestamp` method

### DIFF
--- a/lib/persistence/polling.rb
+++ b/lib/persistence/polling.rb
@@ -21,6 +21,14 @@ module Persistence
       amazon_s3.export file_name: file, objects: objects
     end
 
+    # This methods makes sure no duplicates are made from the QBWC Response. It'll overwrite
+    # older files ensure the only most recent collection is saved
+    def save_for_polling_without_timestamp
+      polling_path = @config[:origin] == 'quickbooks' ? path.qb_pending : path.pending
+      file = "#{path.base_name}/#{polling_path}/#{payload_key}_.json"
+      amazon_s3.export file_name: file, objects: objects
+    end
+
     def save_for_query_later
       file = "#{path.base_name}/#{path.pending}/query_#{payload_key}_#{current_time}.json"
       amazon_s3.export file_name: file, objects: objects

--- a/lib/qbwc/response/item_site_query_rs.rb
+++ b/lib/qbwc/response/item_site_query_rs.rb
@@ -28,7 +28,7 @@ module QBWC
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == "origin"}
 
           poll_persistence = Persistence::Polling.new(config, payload)
-          poll_persistence.save_for_polling
+          poll_persistence.save_for_polling_without_timestamp
 
           inventory_params['inventorywithsites']['quickbooks_force_config'] = 'true'
           params = inventory_params['inventorywithsites']


### PR DESCRIPTION
- Timestamps aren't available when we're processing the records back to
Flowlink so the best solution was to save the most recent one by
overriding older files. The format had to be the same to find the file
so everything before the timestamp , including the underscore, has the
to be included.