### PR TITLE
Change payload name from `inventoryproducts` to `products`

### DIFF
--- a/lib/qbwc/response/item_inventory_query_rs.rb
+++ b/lib/qbwc/response/item_inventory_query_rs.rb
@@ -32,7 +32,7 @@ module QBWC
         end
 
         if product_params
-          payload = { inventoryproducts: products_to_flowlink }
+          payload = { products: products_to_flowlink }
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == "origin"}
           poll_persistence = Persistence::Polling.new(config, payload)
           poll_persistence.save_for_polling_without_timestamp


### PR DESCRIPTION
- The default get_products flow return `item_inventory_query_rs` and it
needs the key to be called `products` to return itself. Originally
thought that `product_params` is for `get_inventoryproducts`.