### PR TITLE
Fix/guid not on payload

### DIFF
--- a/quickbooks_desktop_endpoint.rb
+++ b/quickbooks_desktop_endpoint.rb
@@ -101,9 +101,6 @@ class QuickbooksDesktopEndpoint < EndpointBase::Sinatra::Base
       
       add_flow_return_payload if @return_payload
 
-      puts  "HERE 1"
-      puts @payload
-
       integration = Persistence::Object.new(config, @payload)
       integration.save
 
@@ -238,7 +235,7 @@ class QuickbooksDesktopEndpoint < EndpointBase::Sinatra::Base
   def generate_and_add_guid
     @return_payload ||= {}
     guid = "{#{SecureRandom.uuid.upcase}}"
-    
+
     @payload[object_type][:external_guid] = guid
     @return_payload[:external_guid] = guid
   end

--- a/quickbooks_desktop_endpoint.rb
+++ b/quickbooks_desktop_endpoint.rb
@@ -101,6 +101,9 @@ class QuickbooksDesktopEndpoint < EndpointBase::Sinatra::Base
       
       add_flow_return_payload if @return_payload
 
+      puts  "HERE 1"
+      puts @payload
+
       integration = Persistence::Object.new(config, @payload)
       integration.save
 
@@ -234,7 +237,10 @@ class QuickbooksDesktopEndpoint < EndpointBase::Sinatra::Base
 
   def generate_and_add_guid
     @return_payload ||= {}
-    @return_payload[:external_guid] = "{#{SecureRandom.uuid.upcase}}"
+    guid = "{#{SecureRandom.uuid.upcase}}"
+    
+    @payload[object_type][:external_guid] = guid
+    @return_payload[:external_guid] = guid
   end
 
   def add_return_attributes_to_return_payload


### PR DESCRIPTION
Through all the refactors/fixes for the guid I stopped updating the actual payload that gets stored on S3. So we were never storing the guid in QBE and it messed up when coming back to FL.