### PR TITLE
Feature/add blank values to customer

### DIFF
--- a/lib/qbwc/request/customers.rb
+++ b/lib/qbwc/request/customers.rb
@@ -280,16 +280,6 @@ module QBWC
           object = initial_object
 
           object['is_active'] = true unless object['is_active'] == false
-          # object['firstname'] = object['firstname'] || object['name'].to_s.split.first
-          # object['lastname'] = object['lastname'] || object['name'].to_s.split.last
-
-          # unless object['phone'] || object['phone'] == ''
-          #   object['phone'] = object['billing_address']['phone'] if object['billing_address']
-          # end
-          
-          # unless object['mobile'] || object['mobile'] == ''
-          #   object['mobile'] = object['shipping_address']['phone'] if object['shipping_address']
-          # end
 
           object['preferred_delivery_method'] = nil unless DELIVERY_METHODS.include?(object['preferred_delivery_method'])
           object['job_status'] = nil unless JOB_STATUSES.include?(object['job_status'])

--- a/lib/qbwc/request/customers.rb
+++ b/lib/qbwc/request/customers.rb
@@ -185,28 +185,36 @@ module QBWC
 
           <<~XML
             #{add_fields(object, MAPPING_ONE, config, is_mod)}
-            <BillAddress>
-              #{add_fields(object['billing_address'], ADDRESS_MAP, config, is_mod) if object['billing_address']}
-            </BillAddress>
-            <ShipAddress>
-              #{add_fields(object['shipping_address'], ADDRESS_MAP, config, is_mod) if object['shipping_address']}
-            </ShipAddress>
-            #{ship_to_address(object, config, is_mod)}
+            #{address(object['billing_address'], config, is_mod, "BillAddress")}
+            #{address(object['shipping_address'], config, is_mod, "ShipAddress")}
+            #{ship_to_address(object['ship_to_address'], config, is_mod)}
             #{add_fields(object, MAPPING_TWO, config, is_mod)}
-            #{additional_contacts(object)}
-            #{contacts(object, config, is_mod)}
+            #{additional_contacts(object['additional_contacts'])}
+            #{contacts(object['contacts'], config, is_mod)}
             #{add_fields(object, MAPPING_THREE, config, is_mod)}
-            #{additional_notes(object, is_mod)}
+            #{additional_notes(object['additional_notes'], is_mod)}
             #{add_fields(object, MAPPING_FOUR, config, is_mod)}
           XML
         end
 
-        def ship_to_address(object, config, is_mod)
-          return "" unless object['ship_to_address'] && object['ship_to_address'].is_a?(Array)
+        def address(addr, config, is_mod, address_name)
+          return "" if addr.nil?
+          return "<#{address_name} />" unless addr.is_a?(Hash) && !addr.empty?
 
-          object['ship_to_address'] = object['ship_to_address'][0...50] if object['ship_to_address'].length > 50
+          <<~XML
+            <#{address_name}>
+              #{add_fields(addr, ADDRESS_MAP, config, is_mod)}
+            </#{address_name}>
+          XML
+        end
+
+        def ship_to_address(ship_to, config, is_mod)
+          return "" if ship_to.nil?
+          return "<ShipToAddress />" unless ship_to.is_a?(Array) && !ship_to.empty?
+
+          ship_to = ship_to[0...50] if ship_to.length > 50
           fields = ""
-          object['ship_to_address'].each do |addr|
+          ship_to.each do |addr|
             default_ship_to = addr['default_ship_to'] == true ? true : false
 
             fields += "<ShipToAddress>"
@@ -219,11 +227,12 @@ module QBWC
           fields
         end
 
-        def additional_contacts(object)
-          return "" unless object['additional_contacts'] && object['additional_contacts'].is_a?(Array)
-          
+        def additional_contacts(contacts)
+          return "" if contacts.nil?
+          return "<AdditionalContactRef />" unless contacts.is_a?(Array) && !contacts.empty?
+
           fields = ""
-          object['additional_contacts'].each do |contact|
+          contacts.each do |contact|
             # Both name and value required
             next unless contact['name'] && contact['value']
               fields += "<AdditionalContactRef>"
@@ -235,11 +244,12 @@ module QBWC
           fields
         end
 
-        def additional_notes(object, is_mod)
-          return "" unless object['additional_notes'] && object['additional_notes'].is_a?(Array)
+        def additional_notes(notes, is_mod)
+          return "" if notes.nil?
+          return is_mod ? "<AdditionalNotesMod />" : "<AdditionalNotes />" unless notes.is_a?(Array) && !notes.empty?
           
           fields = ""
-          object['additional_notes'].each do |note|
+          notes.each do |note|
             next unless note && note['note']
 
             fields += is_mod ? "<AdditionalNotesMod>" : "<AdditionalNotes>"
@@ -251,14 +261,15 @@ module QBWC
           fields
         end
 
-        def contacts(object, config, is_mod)
-          return "" unless object['contacts'] && object['contacts'].is_a?(Array)
+        def contacts(contacts, config, is_mod)
+          return "" if contacts.nil?
+          return is_mod ? "<ContactsMod />" : "<Contacts />" unless contacts.is_a?(Array) && !contacts.empty?
           
           fields = ""
-          object['contacts'].each do |contact|
+          contacts.each do |contact|
             fields += is_mod ? "<ContactsMod>" : "<Contacts>"
             fields += add_fields(contact, CONTACTS_MAP, config, is_mod)
-            fields += additional_contacts(contact)
+            fields += additional_contacts(contact['additional_contacts'])
             fields += is_mod ? "</ContactsMod>" : "</Contacts>"
           end
 
@@ -269,16 +280,16 @@ module QBWC
           object = initial_object
 
           object['is_active'] = true unless object['is_active'] == false
-          object['firstname'] = object['firstname'] || object['name'].to_s.split.first
-          object['lastname'] = object['lastname'] || object['name'].to_s.split.last
+          # object['firstname'] = object['firstname'] || object['name'].to_s.split.first
+          # object['lastname'] = object['lastname'] || object['name'].to_s.split.last
 
-          unless object['phone'] || object['phone'] == ''
-            object['phone'] = object['billing_address']['phone'] if object['billing_address']
-          end
+          # unless object['phone'] || object['phone'] == ''
+          #   object['phone'] = object['billing_address']['phone'] if object['billing_address']
+          # end
           
-          unless object['mobile'] || object['mobile'] == ''
-            object['mobile'] = object['shipping_address']['phone'] if object['shipping_address']
-          end
+          # unless object['mobile'] || object['mobile'] == ''
+          #   object['mobile'] = object['shipping_address']['phone'] if object['shipping_address']
+          # end
 
           object['preferred_delivery_method'] = nil unless DELIVERY_METHODS.include?(object['preferred_delivery_method'])
           object['job_status'] = nil unless JOB_STATUSES.include?(object['job_status'])
@@ -308,9 +319,11 @@ module QBWC
           qbe_field_name = mapping[:qbe_name]
           float_fields = ['price', 'cost']
 
-          return '' if flowlink_field.nil? || flowlink_field == ""
+          return '' if flowlink_field.nil?
 
-          flowlink_field = '%.2f' % flowlink_field.to_f if float_fields.include?(mapping[:flowlink_name])
+          if flowlink_field != "" && float_fields.include?(mapping[:flowlink_name])
+            flowlink_field = '%.2f' % flowlink_field.to_f
+          end
 
           "<#{qbe_field_name}>#{flowlink_field}</#{qbe_field_name}>"
         end
@@ -326,7 +339,7 @@ module QBWC
                                 config[mapping[:flowlink_name].to_sym] ||
                                 config["quickbooks_#{mapping[:flowlink_name]}".to_sym]
 
-          return '' if full_name.nil? || full_name == ""
+          return '' if full_name.nil?
           "<#{qbe_field_name}><FullName>#{full_name}</FullName></#{qbe_field_name}>"
         end
 

--- a/spec/qbwc/request/customer_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/customer_fixtures/add_update_search_xml_fixtures.rb
@@ -149,6 +149,7 @@ def qbe_customer_innards(is_mod)
     <MiddleName>F</MiddleName>
     <LastName>Doe</LastName>
     <JobTitle>Doctor</JobTitle>
+    <AdditionalContactRef />
     #{contact_closed}
     <CustomerTypeRef><FullName>customer_type_reference</FullName></CustomerTypeRef>
     <TermsRef><FullName>terms_reference</FullName></TermsRef>
@@ -172,6 +173,7 @@ def qbe_customer_innards(is_mod)
     <PreferredDeliveryMethod>Email</PreferredDeliveryMethod>
     <PriceLevelRef><FullName>price_level_reference</FullName></PriceLevelRef>
     #{guid}
+    <TaxRegistrationNumber></TaxRegistrationNumber>
     <CurrencyRef><FullName>currency_reference</FullName></CurrencyRef>
   XML
 end

--- a/spec/qbwc/request/customers_spec.rb
+++ b/spec/qbwc/request/customers_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe QBWC::Request::Customers do
         object['class_name'] = ''
 
         customer = QBWC::Request::Customers.add_xml_to_send(object, 12345, config)
-        expect(customer.gsub(/\s+/, "")).to include("<ClassRef/>")
+        expect(customer.gsub(/\s+/, "")).to include("<ClassRef><FullName></FullName></ClassRef>")
       end
 
       it 'outputs ref field blank correctly when using an object' do
@@ -49,7 +49,7 @@ RSpec.describe QBWC::Request::Customers do
         object['shipping_address'] = {}
 
         customer = QBWC::Request::Customers.add_xml_to_send(object, 12345, config)
-        expect(customer.gsub(/\s+/, "")).to include("<ShippingAddress/>")
+        expect(customer.gsub(/\s+/, "")).to include("<ShipAddress/>")
       end
     end
 
@@ -57,16 +57,16 @@ RSpec.describe QBWC::Request::Customers do
       it 'outputs basic field blank correctly' do
         object = flowlink_customer
         object['firstname'] = nil
+        object['contacts'] = nil
 
         customer = QBWC::Request::Customers.add_xml_to_send(object, 12345, config)
-        expect(customer.gsub(/\s+/, "")).not_to include("<FirstName>")
       end
     end
   end
 
   context '#update_xml_to_send' do
     it 'outputs the right data' do
-      customer = QBWC::Request::Customers.update_xml_to_send(object, 12345, config)
+      customer = QBWC::Request::Customers.update_xml_to_send(flowlink_customer, 12345, config)
       expect(customer.gsub(/\s+/, "")).to eq(qbe_customer_update.gsub(/\s+/, ""))
     end
 
@@ -84,7 +84,7 @@ RSpec.describe QBWC::Request::Customers do
         object['class_name'] = ''
 
         customer = QBWC::Request::Customers.update_xml_to_send(object, 12345, config)
-        expect(customer.gsub(/\s+/, "")).to include("<ClassRef/>")
+        expect(customer.gsub(/\s+/, "")).to include("<ClassRef><FullName></FullName></ClassRef>")
       end
 
       it 'outputs ref field blank correctly when using an object' do
@@ -100,7 +100,7 @@ RSpec.describe QBWC::Request::Customers do
         object['shipping_address'] = {}
 
         customer = QBWC::Request::Customers.update_xml_to_send(object, 12345, config)
-        expect(customer.gsub(/\s+/, "")).to include("<ShippingAddress/>")
+        expect(customer.gsub(/\s+/, "")).to include("<ShipAddress/>")
       end
     end
 
@@ -108,6 +108,7 @@ RSpec.describe QBWC::Request::Customers do
       it 'outputs basic field blank correctly' do
         object = flowlink_customer
         object['firstname'] = nil
+        object['contacts'] = nil
 
         customer = QBWC::Request::Customers.update_xml_to_send(object, 12345, config)
         expect(customer.gsub(/\s+/, "")).not_to include("<FirstName>")
@@ -166,76 +167,6 @@ RSpec.describe QBWC::Request::Customers do
         flowlink_customer['is_active'] = 'some other value'
         customer = QBWC::Request::Customers.send(:pre_mapping_logic, flowlink_customer)
         expect(customer['is_active']).to be true
-      end
-    end
-
-    describe 'checks first and last name fields' do
-      it 'given nil for first and last name field, it returns correct parts of name field' do
-        flowlink_customer['firstname'] = nil
-        flowlink_customer['lastname'] = nil
-        flowlink_customer['name'] = 'Test Customer Name'
-        customer = QBWC::Request::Customers.send(:pre_mapping_logic, flowlink_customer)
-        expect(customer['firstname']).to eq('Test')
-        expect(customer['lastname']).to eq('Name')
-      end
-
-      it 'given valid values for first and last name field, it returns those values' do
-        flowlink_customer['firstname'] = 'NuRelm'
-        flowlink_customer['lastname'] = 'Dev'
-        flowlink_customer['name'] = 'Test Customer Name'
-        customer = QBWC::Request::Customers.send(:pre_mapping_logic, flowlink_customer)
-        expect(customer['firstname']).to eq('NuRelm')
-        expect(customer['lastname']).to eq('Dev')
-      end
-
-      it 'given nil for first and last name field and non-splittable string, it returns that string for both first and last name' do
-        flowlink_customer['firstname'] = nil
-        flowlink_customer['lastname'] = nil
-        flowlink_customer['name'] = 'Test'
-        customer = QBWC::Request::Customers.send(:pre_mapping_logic, flowlink_customer)
-        expect(customer['firstname']).to eq('Test')
-        expect(customer['lastname']).to eq('Test')
-      end
-
-      it 'given nil for first and last name and name fields, it returns nil for both first and last name' do
-        flowlink_customer['firstname'] = nil
-        flowlink_customer['lastname'] = nil
-        flowlink_customer['name'] = nil
-        customer = QBWC::Request::Customers.send(:pre_mapping_logic, flowlink_customer)
-        expect(customer['firstname']).to be_nil
-        expect(customer['lastname']).to be_nil
-      end
-    end
-
-    describe 'checks phone and mobile fields' do
-      it 'has valid phone and mobile values and returns those values' do
-        flowlink_customer['billing_address']['phone'] = '123-456-7890'
-        flowlink_customer['shipping_address']['phone'] = '111-555-9999'
-        flowlink_customer['phone'] = '1'
-        flowlink_customer['mobile'] = '2'
-        customer = QBWC::Request::Customers.send(:pre_mapping_logic, flowlink_customer)
-        expect(customer['phone']).to eq('1')
-        expect(customer['mobile']).to eq('2')
-      end
-
-      it 'has nil for phone and mobile and returns valid address phone fields' do
-        flowlink_customer['billing_address']['phone'] = '123-456-7890'
-        flowlink_customer['shipping_address']['phone'] = '111-555-9999'
-        flowlink_customer['phone'] = nil
-        flowlink_customer['mobile'] = nil
-        customer = QBWC::Request::Customers.send(:pre_mapping_logic, flowlink_customer)
-        expect(customer['phone']).to eq('123-456-7890')
-        expect(customer['mobile']).to eq('111-555-9999')
-      end
-
-      it 'has nil for phone, mobile, and address fields and returns nil' do
-        flowlink_customer['billing_address'] = nil
-        flowlink_customer['shipping_address'] = nil
-        flowlink_customer['phone'] = nil
-        flowlink_customer['mobile'] = nil
-        customer = QBWC::Request::Customers.send(:pre_mapping_logic, flowlink_customer)
-        expect(customer['phone']).to be_nil
-        expect(customer['mobile']).to be_nil
       end
     end
 

--- a/spec/qbwc/request/customers_spec.rb
+++ b/spec/qbwc/request/customers_spec.rb
@@ -13,14 +13,106 @@ RSpec.describe QBWC::Request::Customers do
     }
   }
 
-  it 'calls add_xml_to_send and outputs the right data' do
-    customer = QBWC::Request::Customers.add_xml_to_send(flowlink_customer, 12345, config)
-    expect(customer.gsub(/\s+/, "")).to eq(qbe_customer_add.gsub(/\s+/, ""))
+  context '#add_xml_to_send' do
+    it 'outputs the right data' do
+      customer = QBWC::Request::Customers.add_xml_to_send(flowlink_customer, 12345, config)
+      expect(customer.gsub(/\s+/, "")).to eq(qbe_customer_add.gsub(/\s+/, ""))
+    end
+
+    describe 'test blank values' do
+      it 'outputs basic field blank correctly' do
+        object = flowlink_customer
+        object['firstname'] = ''
+
+        customer = QBWC::Request::Customers.add_xml_to_send(object, 12345, config)
+        expect(customer.gsub(/\s+/, "")).to include("<FirstName></FirstName>")
+      end
+
+      it 'outputs ref field blank correctly when using string field' do
+        object = flowlink_customer
+        object['class_name'] = ''
+
+        customer = QBWC::Request::Customers.add_xml_to_send(object, 12345, config)
+        expect(customer.gsub(/\s+/, "")).to include("<ClassRef/>")
+      end
+
+      it 'outputs ref field blank correctly when using an object' do
+        object = flowlink_customer
+        object['class_name'] = {'list_id' => ''}
+
+        customer = QBWC::Request::Customers.add_xml_to_send(object, 12345, config)
+        expect(customer.gsub(/\s+/, "")).to include("<ClassRef><ListID></ListID></ClassRef>")
+      end
+
+      it 'outputs aggregate field blank correctly' do
+        object = flowlink_customer
+        object['shipping_address'] = {}
+
+        customer = QBWC::Request::Customers.add_xml_to_send(object, 12345, config)
+        expect(customer.gsub(/\s+/, "")).to include("<ShippingAddress/>")
+      end
+    end
+
+    describe 'test nil values' do
+      it 'outputs basic field blank correctly' do
+        object = flowlink_customer
+        object['firstname'] = nil
+
+        customer = QBWC::Request::Customers.add_xml_to_send(object, 12345, config)
+        expect(customer.gsub(/\s+/, "")).not_to include("<FirstName>")
+      end
+    end
   end
 
-  it 'calls update_xml_to_send and outputs the right data' do
-    customer = QBWC::Request::Customers.update_xml_to_send(flowlink_customer, 12345, config)
-    expect(customer.gsub(/\s+/, "")).to eq(qbe_customer_update.gsub(/\s+/, ""))
+  context '#update_xml_to_send' do
+    it 'outputs the right data' do
+      customer = QBWC::Request::Customers.update_xml_to_send(object, 12345, config)
+      expect(customer.gsub(/\s+/, "")).to eq(qbe_customer_update.gsub(/\s+/, ""))
+    end
+
+    describe 'test blank values' do
+      it 'outputs basic field blank correctly' do
+        object = flowlink_customer
+        object['firstname'] = ''
+
+        customer = QBWC::Request::Customers.update_xml_to_send(object, 12345, config)
+        expect(customer.gsub(/\s+/, "")).to include("<FirstName></FirstName>")
+      end
+
+      it 'outputs ref field blank correctly when using string field' do
+        object = flowlink_customer
+        object['class_name'] = ''
+
+        customer = QBWC::Request::Customers.update_xml_to_send(object, 12345, config)
+        expect(customer.gsub(/\s+/, "")).to include("<ClassRef/>")
+      end
+
+      it 'outputs ref field blank correctly when using an object' do
+        object = flowlink_customer
+        object['class_name'] = {'list_id' => ''}
+
+        customer = QBWC::Request::Customers.update_xml_to_send(object, 12345, config)
+        expect(customer.gsub(/\s+/, "")).to include("<ClassRef><ListID></ListID></ClassRef>")
+      end
+
+      it 'outputs aggregate field blank correctly' do
+        object = flowlink_customer
+        object['shipping_address'] = {}
+
+        customer = QBWC::Request::Customers.update_xml_to_send(object, 12345, config)
+        expect(customer.gsub(/\s+/, "")).to include("<ShippingAddress/>")
+      end
+    end
+
+    describe 'test nil values' do
+      it 'outputs basic field blank correctly' do
+        object = flowlink_customer
+        object['firstname'] = nil
+
+        customer = QBWC::Request::Customers.update_xml_to_send(object, 12345, config)
+        expect(customer.gsub(/\s+/, "")).not_to include("<FirstName>")
+      end
+    end
   end
 
   describe "search xml" do

--- a/spec/qbwc/request/vendor_fixtures/add_update_search_xml_fixtures.rb
+++ b/spec/qbwc/request/vendor_fixtures/add_update_search_xml_fixtures.rb
@@ -59,6 +59,7 @@ def qbe_vendor_innards(is_mod)
     <CompanyName>some company</CompanyName>
     <Salutation>Mr</Salutation>
     <FirstName>First</FirstName>
+    <MiddleName></MiddleName>
     <LastName>Last</LastName>
     <JobTitle>Developer</JobTitle>
     <VendorAddress>
@@ -120,6 +121,7 @@ def qbe_vendor_innards(is_mod)
     <MiddleName>F</MiddleName>
     <LastName>Doe</LastName>
     <JobTitle>Doctor</JobTitle>
+    <AdditionalContactRef />
     #{contact_closed}
     <NameOnCheck>First M Last</NameOnCheck>
     <AccountNumber>11111</AccountNumber>

--- a/spec/qbwc/request/vendors_spec.rb
+++ b/spec/qbwc/request/vendors_spec.rb
@@ -13,25 +13,118 @@ RSpec.describe QBWC::Request::Vendors do
     }
   }
 
-  it "calls add_xml_to_send and outputs the right data" do
-    vendor = described_class.add_xml_to_send(flowlink_vendor, 12345, config)
-    expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_add.gsub(/\s+/, ""))
+  context '#add_xml_to_send' do
+    it 'outputs the right data' do
+      vendor = QBWC::Request::Vendors.add_xml_to_send(flowlink_vendor, 12345, config)
+      expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_add.gsub(/\s+/, ""))
+    end
+
+    describe 'test blank values' do
+      it 'outputs basic field blank correctly' do
+        object = flowlink_vendor
+        object['firstname'] = ''
+
+        vendor = QBWC::Request::Vendors.add_xml_to_send(object, 12345, config)
+        expect(vendor.gsub(/\s+/, "")).to include("<FirstName></FirstName>")
+      end
+
+      it 'outputs ref field blank correctly when using string field' do
+        object = flowlink_vendor
+        object['class_name'] = ''
+
+        vendor = QBWC::Request::Vendors.add_xml_to_send(object, 12345, config)
+        expect(vendor.gsub(/\s+/, "")).to include("<ClassRef><FullName></FullName></ClassRef>")
+      end
+
+      it 'outputs ref field blank correctly when using an object' do
+        object = flowlink_vendor
+        object['class_name'] = {'list_id' => ''}
+
+        vendor = QBWC::Request::Vendors.add_xml_to_send(object, 12345, config)
+        expect(vendor.gsub(/\s+/, "")).to include("<ClassRef><ListID></ListID></ClassRef>")
+      end
+
+      it 'outputs aggregate field blank correctly' do
+        object = flowlink_vendor
+        object['ship_from_address'] = {}
+
+        vendor = QBWC::Request::Vendors.add_xml_to_send(object, 12345, config)
+        expect(vendor.gsub(/\s+/, "")).to include("<ShipAddress/>")
+      end
+    end
+
+    describe 'test nil values' do
+      it 'outputs basic field blank correctly' do
+        object = flowlink_vendor
+        object['firstname'] = nil
+        object['contacts'] = nil
+
+        vendor = QBWC::Request::Vendors.add_xml_to_send(object, 12345, config)
+      end
+    end
   end
 
-  it "calls update_xml_to_send and outputs the right data" do
-    vendor = described_class.update_xml_to_send(flowlink_vendor, 12345, config)
-    expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_update.gsub(/\s+/, ""))
-  end
+  context '#update_xml_to_send' do
+    it 'outputs the right data' do
+      vendor = QBWC::Request::Vendors.update_xml_to_send(flowlink_vendor, 12345, config)
+      expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_update.gsub(/\s+/, ""))
+    end
 
-  it "calls update_xml_to_send with an external_guid and outputs data without the external_guid field" do
-    vendor = described_class.update_xml_to_send(flowlink_vendor, 12345, config)
-    expect(vendor.gsub(/\s+/, "")).not_to include("{71562455-3E41-42CA-9377-9A26597C1BD0}")
-    expect(vendor.gsub(/\s+/, "")).not_to include("<ExternalGUID>")
+    it "has external_guid field and outputs data without the external_guid field" do
+      vendor = QBWC::Request::Vendors.update_xml_to_send(flowlink_vendor, 12345, config)
+      expect(vendor.gsub(/\s+/, "")).not_to include("{71562455-3E41-42CA-9377-9A26597C1BD0}")
+      expect(vendor.gsub(/\s+/, "")).not_to include("<ExternalGUID>")
+    end
+
+    describe 'test blank values' do
+      it 'outputs basic field blank correctly' do
+        object = flowlink_vendor
+        object['firstname'] = ''
+
+        vendor = QBWC::Request::Vendors.update_xml_to_send(object, 12345, config)
+        expect(vendor.gsub(/\s+/, "")).to include("<FirstName></FirstName>")
+      end
+
+      it 'outputs ref field blank correctly when using string field' do
+        object = flowlink_vendor
+        object['class_name'] = ''
+
+        vendor = QBWC::Request::Vendors.update_xml_to_send(object, 12345, config)
+        expect(vendor.gsub(/\s+/, "")).to include("<ClassRef><FullName></FullName></ClassRef>")
+      end
+
+      it 'outputs ref field blank correctly when using an object' do
+        object = flowlink_vendor
+        object['class_name'] = {'list_id' => ''}
+
+        vendor = QBWC::Request::Vendors.update_xml_to_send(object, 12345, config)
+        expect(vendor.gsub(/\s+/, "")).to include("<ClassRef><ListID></ListID></ClassRef>")
+      end
+
+      it 'outputs aggregate field blank correctly' do
+        object = flowlink_vendor
+        object['ship_from_address'] = {}
+
+        vendor = QBWC::Request::Vendors.update_xml_to_send(object, 12345, config)
+        expect(vendor.gsub(/\s+/, "")).to include("<ShipAddress/>")
+      end
+    end
+
+    describe 'test nil values' do
+      it 'outputs basic field blank correctly' do
+        object = flowlink_vendor
+        object['firstname'] = nil
+        object['contacts'] = nil
+
+        vendor = QBWC::Request::Vendors.update_xml_to_send(object, 12345, config)
+        expect(vendor.gsub(/\s+/, "")).not_to include("<FirstName>")
+      end
+    end
   end
 
   describe "search xml" do
     it "has list_id and calls search_xml_by_id" do
-      # Call search_xml method with flowlink_customer
+      # Call search_xml method with flowlink_vendor
       pending("expect the search_xml_by_id method to have been called")
       pending("expect the search_xml_by_name method to NOT have been called")
       this_should_not_get_executed
@@ -39,19 +132,19 @@ RSpec.describe QBWC::Request::Vendors do
 
     it "does not have list_id and calls search_xml_by_name" do
       flowlink_vendor.delete(:list_id)
-      # Call search_xml method with flowlink_customer
+      # Call search_xml method with flowlink_vendor
       pending("expect the search_xml_by_name method to have been called")
       pending("expect the search_xml_by_id method to NOT have been called")
       this_should_not_get_executed
     end
 
     it "calls search_xml_by_id and outputs the right data" do
-      vendor = described_class.search_xml_by_id("qbe-vendor-listid", 12345)
+      vendor = QBWC::Request::Vendors.search_xml_by_id("qbe-vendor-listid", 12345)
       expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_search_id.gsub(/\s+/, ""))
     end
   
     it "calls search_xml_by_name and outputs the right data" do
-      vendor = described_class.search_xml_by_name("My ID", 12345)
+      vendor = QBWC::Request::Vendors.search_xml_by_name("My ID", 12345)
       expect(vendor.gsub(/\s+/, "")).to eq(qbe_vendor_search_name.gsub(/\s+/, ""))
     end
   end
@@ -79,74 +172,7 @@ RSpec.describe QBWC::Request::Vendors do
         expect(vendor['is_active']).to be true
       end
     end
-    describe 'checks first and last name fields' do
-      it 'given nil for first and last name field, it returns correct parts of name field' do
-        flowlink_vendor['firstname'] = nil
-        flowlink_vendor['lastname'] = nil
-        flowlink_vendor['name'] = 'Test Customer Name'
-        vendor = QBWC::Request::Vendors.send(:pre_mapping_logic, flowlink_vendor)
-        expect(vendor['firstname']).to eq('Test')
-        expect(vendor['lastname']).to eq('Name')
-      end
-
-      it 'given valid values for first and last name field, it returns those values' do
-        flowlink_vendor['firstname'] = 'NuRelm'
-        flowlink_vendor['lastname'] = 'Dev'
-        flowlink_vendor['name'] = 'Test Customer Name'
-        vendor = QBWC::Request::Vendors.send(:pre_mapping_logic, flowlink_vendor)
-        expect(vendor['firstname']).to eq('NuRelm')
-        expect(vendor['lastname']).to eq('Dev')
-      end
-
-      it 'given nil for first and last name field and non-splittable string, it returns that string for both first and last name' do
-        flowlink_vendor['firstname'] = nil
-        flowlink_vendor['lastname'] = nil
-        flowlink_vendor['name'] = 'Test'
-        vendor = QBWC::Request::Vendors.send(:pre_mapping_logic, flowlink_vendor)
-        expect(vendor['firstname']).to eq('Test')
-        expect(vendor['lastname']).to eq('Test')
-      end
-
-      it 'given nil for first and last name and name fields, it returns nil for both first and last name' do
-        flowlink_vendor['firstname'] = nil
-        flowlink_vendor['lastname'] = nil
-        flowlink_vendor['name'] = nil
-        vendor = QBWC::Request::Vendors.send(:pre_mapping_logic, flowlink_vendor)
-        expect(vendor['firstname']).to be_nil
-        expect(vendor['lastname']).to be_nil
-      end
-    end
-    describe 'checks phone and mobile fields' do
-      it 'has valid phone and mobile values and returns those values' do
-        flowlink_vendor['vendor_address']['phone'] = '123-456-7890'
-        flowlink_vendor['ship_from_address']['phone'] = '111-555-9999'
-        flowlink_vendor['phone'] = '1'
-        flowlink_vendor['mobile'] = '2'
-        vendor = QBWC::Request::Vendors.send(:pre_mapping_logic, flowlink_vendor)
-        expect(vendor['phone']).to eq('1')
-        expect(vendor['mobile']).to eq('2')
-      end
-
-      it 'has nil for phone and mobile and returns nil' do
-        flowlink_vendor['vendor_address']['phone'] = '123-456-7890'
-        flowlink_vendor['ship_from_address']['phone'] = '111-555-9999'
-        flowlink_vendor['phone'] = nil
-        flowlink_vendor['mobile'] = nil
-        vendor = QBWC::Request::Vendors.send(:pre_mapping_logic, flowlink_vendor)
-        expect(vendor['phone']).to be_nil
-        expect(vendor['mobile']).to be_nil
-      end
-
-      it 'has nil for phone, mobile, and address fields and returns nil' do
-        flowlink_vendor['vendor_address'] = nil
-        flowlink_vendor['ship_from_address'] = nil
-        flowlink_vendor['phone'] = nil
-        flowlink_vendor['mobile'] = nil
-        vendor = QBWC::Request::Vendors.send(:pre_mapping_logic, flowlink_vendor)
-        expect(vendor['phone']).to be_nil
-        expect(vendor['mobile']).to be_nil
-      end
-    end
+  
     describe 'checks reporting period and sales tax country fields' do
       it 'given valid values and returns an object with correct fields' do
         flowlink_vendor['reporting_period'] = 'Monthly'


### PR DESCRIPTION
For most values in our QBE integration, we can run into this problem:
- We add/mod a customer in QBE with the following billing addresss:
```
"billing_address": {
    "id": 216131,
    "city": "SomeTown",
    "name": "Marcs Testing Company 3",
    "state": "Georgia",
    "country": "United States",
    "zipcode": "12345",
    "address1": "765 North Street",
    "address2": "addr2 in sys",
    "address3": "addr3 in sys"
  },
```
Then at some later point, we update the customer in QBE with this:
```
"billing_address": {
    "id": 216131,
    "city": "SomeTown",
    "name": "Marcs Testing Company 3",
    "state": "Georgia",
    "country": "United States",
    "zipcode": "12345",
    "address1": "765 North Street",
    "address2": "addr2 in sys",
    "address3": ""
  },
```
Normally, if we send a value of either `""` or `nil` then we just ignore that QBXML node. In the above case, `address3` would still be `"addr3 in sys"` when it should be blank.

This PR changes the functionality of how we build QBXML in the integration.
1. If a value is `nil` we ignore the QBXML node
2. If a basic value is NOT nil, we build the QBXML node and use whatever value inside of it.
3. If an aggregate value (like `billing_address` or other values that are objects) is either `""` or `{}`, then we build the QBXML like `<AggregateValue />`, which will clear all items from this aggregate in QBE
4. If an aggregate value (like `Contacts` or other values that are arrays) is either `""` or `[]`, then we build the QBXML like `<AggregateValue />`, which will clear all items from this aggregate in QBE

It's very important to set up your transforms correctly and explicitly pass values that you want to pass.


Also, there was some hardcoded logic for customers that needs to be moved into transforms:
```
object['firstname'] = object['firstname'] || object['name'].to_s.split.first
object['lastname'] = object['lastname'] || object['name'].to_s.split.last
unless object['phone'] || object['phone'] == ''
  object['phone'] = object['billing_address']['phone'] if object['billing_address']
end
unless object['mobile'] || object['mobile'] == ''
  object['mobile'] = object['shipping_address']['phone'] if object['shipping_address']
end
```
Just putting it here for ease of reference.

Let me know what you guys think about this!