### PR TITLE
fixed purchase order and sales receipt naming

### DIFF
--- a/quickbooks_desktop_endpoint.rb
+++ b/quickbooks_desktop_endpoint.rb
@@ -54,6 +54,8 @@ CUSTOM_OBJECT_TYPES = %w(
   inventoryproducts
   inventoryassemblyproducts
   otherchargeproducts
+  purchaseorders
+  salesreceipts
 )
 
 OBJECT_TYPES_MAPPING_DATA_OBJECT = {
@@ -64,7 +66,9 @@ OBJECT_TYPES_MAPPING_DATA_OBJECT = {
   'noninventoryproducts' => 'products',
   'inventoryproducts' => 'products',
   'discountproducts' => 'products',
-  'inventoryassemblyproducts' => 'products'
+  'inventoryassemblyproducts' => 'products',
+  'purchaseorders' => 'purchase_orders',
+  'salesreceipts' => 'sales_receipts'
 }
 
 class QuickbooksDesktopEndpoint < EndpointBase::Sinatra::Base


### PR DESCRIPTION
We were returning
```
purchaseorders: [
  {id: 1, external_guid: "{30390923-03i-33093091}
]
```

This wasn't associating with the right PO (or Sales Receipt, I assume) because there isn't a data. object called `purchaseorder`