### PR TITLE
Add a sales_order field in an invoice to use relationships on

### DIFF
--- a/lib/qbwc/response/invoice_query_rs.rb
+++ b/lib/qbwc/response/invoice_query_rs.rb
@@ -190,9 +190,13 @@ module QBWC
             suggested_discount_date: record['SuggestedDiscountDate'].to_s,
             other: record['Other'],
             external_guid: record['ExternalGUID'],
+            sales_order: {
+              title: record['PONumber']
+            },
             relationships: [
               { object: 'customer', key: 'qbe_id' },
-              { object: 'product', key: 'qbe_id', location: 'line_items' }
+              { object: 'product', key: 'qbe_id', location: 'line_items' },
+              { object: 'order', key: 'title', location: 'sales_order' }
             ],
             linked_qbe_transactions: linked_qbe_transactions(record)
           }.compact

--- a/spec/qbwc/response/invoice_fixtures/invoice.json
+++ b/spec/qbwc/response/invoice_fixtures/invoice.json
@@ -1,0 +1,7 @@
+{
+  "ListID": "",
+  "TimeCreated": "2015-02-04T17:22:56-05:00",
+  "TimeModified": "2015-02-04T17:22:56-05:00",
+  "EditSequence": "1423088576",
+  "PONumber": "1ABC"
+}

--- a/spec/qbwc/response/invoice_query_rs_spec.rb
+++ b/spec/qbwc/response/invoice_query_rs_spec.rb
@@ -1,0 +1,45 @@
+require 'rspec'
+require 'json'
+require "active_support/core_ext/hash/indifferent_access"
+require 'qbwc/response/invoice_query_rs'
+
+RSpec.describe QBWC::Response::InvoiceQueryRs do
+  describe "calls inventories_to_flowlink" do
+    let(:invoice_object) { JSON.parse(File.read('spec/qbwc/response/invoice_fixtures/invoice.json')) }
+    let(:expected_invoice) {
+      {
+        "key"=>["qbe_transaction_id", "qbe_id", "external_guid"],
+        "created_at"=>"2015-02-04T17:22:56-05:00",
+        "modified_at"=>"2015-02-04T17:22:56-05:00",
+        "customer"=>{
+          "name"=>nil,
+          "external_id"=>nil,
+          "qbe_id"=>nil
+        },
+        "billing_address"=>{},
+        "shipping_address"=>{},
+        "po_number"=>"1ABC",
+        "due_date"=>"",
+        "sales_rep"=>{"name"=>nil},
+        "shipping_date"=>"",
+        "suggested_discount_date"=>"",
+        "sales_order"=>{"title"=>"1ABC"},
+        "relationships"=>[
+          {"object"=>"customer", "key"=>"qbe_id"},
+          {"object"=>"product", "key"=>"qbe_id", "location"=>"line_items"},
+          {"object"=>"order", "key"=>"title", "location"=>"sales_order"}
+        ]
+      }
+    }
+
+    describe "calls invoices_to_flowlink with one invoice returned" do
+      it "returns expected fields" do
+        invoice_rs = QBWC::Response::InvoiceQueryRs.new([invoice_object])
+        output = invoice_rs.send(:invoices_to_flowlink).first.with_indifferent_access
+        expect(output).to eq(expected_invoice.with_indifferent_access)
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
- This approach is using the PONumber as the id for an order and that
its set in the title of the order. This also assumes that this title
won't be changed in other workflows.