### PR TITLE
Update ItemInventoryQueryRq to selectively remove `MaxReturned`

### DIFF
--- a/lib/qbwc/request/products.rb
+++ b/lib/qbwc/request/products.rb
@@ -143,6 +143,17 @@ module QBWC
           session_id = Persistence::Session.save(config, 'polling' => timestamp)
           time = Time.parse(timestamp).in_time_zone 'Pacific Time (US & Canada)'
 
+          <<~XML
+            <ItemInventoryQueryRq requestID="#{session_id}">
+              #{max_returned(params)}
+              #{query_by_date(params, time)}
+              <OwnerID>0</OwnerID>
+            </ItemInventoryQueryRq>
+          XML
+        end
+
+        def max_returned(params)
+          return '' if params['quickbooks_max_returned'] == '0'
           inventory_max_returned = nil
           inventory_max_returned = 10000 if params['return_all'].to_i == 1
           if params['quickbooks_max_returned'] && params['quickbooks_max_returned'] != ""
@@ -150,42 +161,7 @@ module QBWC
           end
 
           <<~XML
-            <ItemInventoryQueryRq requestID="#{session_id}">
               <MaxReturned>#{inventory_max_returned || 50}</MaxReturned>
-              #{query_by_date(params, time)}
-              <IncludeRetElement>Name</IncludeRetElement>
-              <IncludeRetElement>ListID</IncludeRetElement>
-              <IncludeRetElement>FullName</IncludeRetElement>
-              <IncludeRetElement>QuantityOnHand</IncludeRetElement>
-              <IncludeRetElement>IsActive</IncludeRetElement>
-              <IncludeRetElement>SalesPrice</IncludeRetElement>
-              <IncludeRetElement>PurchaseDesc</IncludeRetElement>
-              <IncludeRetElement>PurchaseCost</IncludeRetElement>
-              <IncludeRetElement>PrefVendorRef</IncludeRetElement>
-              <IncludeRetElement>UnitOfMeasureSetRef</IncludeRetElement>
-              <IncludeRetElement>ClassRef</IncludeRetElement>
-              <IncludeRetElement>ParentRef</IncludeRetElement>
-              <IncludeRetElement>SalesTaxCodeRef</IncludeRetElement>
-              <IncludeRetElement>IncomeAccountRef</IncludeRetElement>
-              <IncludeRetElement>PurchaseTaxCodeRef</IncludeRetElement>
-              <IncludeRetElement>COGSAccountRef</IncludeRetElement>
-              <IncludeRetElement>AssetAccountRef</IncludeRetElement>
-              <IncludeRetElement>AverageCost</IncludeRetElement>
-              <IncludeRetElement>QuantityOnOrder</IncludeRetElement>
-              <IncludeRetElement>QuantityOnSalesOrder</IncludeRetElement>
-              <IncludeRetElement>TimeCreated</IncludeRetElement>
-              <IncludeRetElement>TimeModified</IncludeRetElement>
-              <IncludeRetElement>BarCodeValue</IncludeRetElement>
-              <IncludeRetElement>Sublevel</IncludeRetElement>
-              <IncludeRetElement>ManufacturerPartNumber</IncludeRetElement>
-              <IncludeRetElement>IsTaxIncluded</IncludeRetElement>
-              <IncludeRetElement>SalesDesc</IncludeRetElement>
-              <IncludeRetElement>ReorderPoint</IncludeRetElement>
-              <IncludeRetElement>Max</IncludeRetElement>
-              <IncludeRetElement>ExternalGUID</IncludeRetElement>
-              <IncludeRetElement>DataExtRet</IncludeRetElement>
-              <OwnerID>0</OwnerID>
-            </ItemInventoryQueryRq>
           XML
         end
 

--- a/lib/qbwc/response/item_inventory_query_rs.rb
+++ b/lib/qbwc/response/item_inventory_query_rs.rb
@@ -148,12 +148,29 @@ module QBWC
             reorder_point: record['ReorderPoint'],
             max: record['Max'],
             external_guid: record['ExternalGUID'],
+            custom_fields: custom_fields(record),
             qbe_item_type: 'qbe_inventory'
           }.compact
 
           object
         end
       end
+
+      def custom_fields(object)
+        return nil unless object['DataExtRet']
+
+        object['DataExtRet'].map do |object|
+          {
+            name: object['DataExtName'],
+            owner_id: object['OwnerID'],
+            type: object['DataExtType'],
+            value: object['DataExtValue']
+          }
+        end
+
+      end
+
+
     end
   end
 end


### PR DESCRIPTION
- MaxReturned field is preventing DataExtRet fields from being returned
- When `quickbooks_max_returned` is set to `0`, the `MaxReturned` field
is not used in the query
- Add method in item_inventory_query_rs to return `DataExtRet` with
fields for name, value, type, and owner_id