### PR TITLE
Feature/error report

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The following parameters are required when setting up a Flow with this webhook:
 | receive | I think this gets set within the integration |
 | flow | I think this gets set within the integration |
 | health_check_threshold_in_minutes | Minute threshold to determine if the QBWC is failing it's healthcheck or not |
+| retry_threshold_in_minutes | Minute threshold to determine when to start retrying objects stuck in in_progress folder |
 
 [Adding QBE Refs Readme](./QBE_REFS.md)
 
@@ -170,6 +171,73 @@ creditmemo: {
   # More fields...
 }
 ```
+
+### Integration and S3
+
+#### General File Flow
+
+The general flow of objects that are being added/updated in QuickBooks Enterprise are as follows:
+
+The object gets added to S3 like this:
+
+`<Bucket Name><Folder Name><Phase Folder Name><File Name>`
+
+**Bucket Name**: Bucket named `quickbooks-desktop-integration`
+
+**Folder Name**: Folder within that bucket which corresponds to the `connection_id` found in the config params in the request.
+
+**Phase Folder Name**: Folder within that folder named either `flowlink_pending` or `flowlink_two_phase_pending` based on the object type
+
+**File Name**: File within that folder named as `<object_type_plural>_<id_of_object>_.json`, so a product with an id of 1234 would be named `products_1234_.json`
+
+A full path might be `quickbooks-desktop-integration/my-company/flowlink_two_phase_pending/products_1234_.json`
+
+Then the QBWC hits the integration and the following happens:
+
+* Any objects in `flowlink_pending` are added as QUERY requests to QBE
+
+Then the QBWC returns a response and the following happens:
+
+* Any objects in `flowlink_two_phase_pending` are moved to the `flowlink_pending` folder
+* The objects in `flowlink_pending` are updated with response info from QBE and are moved to the `flowlink_ready` folder
+
+Then the QBWC hits the integration and the following happens:
+
+* Any objects in `flowlink_pending` are added as QUERY requests to QBE
+* Any objects in `flowlink_ready` are added as ADD or MOD requests to QBE
+* The objects in `flowlink_ready` folder are moved to `flowlink_in_progress`
+
+Then the QBWC returns a response and the following happens:
+
+* Any objects in `flowlink_two_phase_pending` are moved to the `flowlink_pending` folder
+* The objects in `flowlink_pending` are updated with response info from QBE and are moved to the `flowlink_ready` folder
+* The objects in `flowlink_in_progress` are updated with response info from QBE and are moved to either `flowlink_processed` folder or the `flowlink_failed` folder
+* NOTE: Some objects may have failed for invalid QBXML or a bug in the code and **will not get moved out of the flowlink_in_progress folder** (See below for **Retrying In Progress Objects**)
+
+The cycle continues...
+
+### Retrying In Progress Objects
+
+The integration combines all requests to QuickBooks into 1 request each time. If an object has invalid QBXML or some other typo/bug, it will cause the entire request to fail (rather than just that single, poorly constructed object). This is why we move files from the `flowlink_ready` folder to the `flowlink_in_progress` folder when trying to ADD/MOD the file (Querying rarely has invalid QBXML).
+
+It helps because:
+
+1. If the request fails, future requests won't contain the object
+2. It allows us to retry valid objects that may have failed simply because they were in the same request as an invalid objects
+
+When the QBWC sends a response back the integration, we run through all the information in the response. Then, we look through the `flowlink_in_progress` folder for any objects to retry. An object only gets retried if all of the following are true:
+
+* **The healthcheck is not failing:** We don't want to retry any objects if the QBWC is down
+* **The object's last_modified is past a certain threshold:** If the object has been sitting in the `flowlink_in_progress` folder for a very short period of time, we should leave it be in case it gets moved out on subsequent requests (See **Retry Threshold** below )
+* **The object has not surpassed the retry limit:** Once we retry an object that gets stuck in the `flowlink_in_progress` folder 3 times, we'll stop retrying it.
+
+When retrying an object, we move it to the `flowlink_pending` folder or the `flowlink_two_phase_pending` folder, based on the object type.
+
+#### Retry Threshold
+
+30 minutes is the default amount of time we use to check if an object has been stuck in the `flowlink_in_progress` folder long enough to retry.
+
+Sometimes clients will need to run their QBWC at much slower rates, so you may override this default using the config param `retry_threshold_in_minutes`
 
 ### Running the Health Check
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ The following parameters are required when setting up a Flow with this webhook:
 | receive | I think this gets set within the integration |
 | flow | I think this gets set within the integration |
 | health_check_threshold_in_minutes | Minute threshold to determine if the QBWC is failing it's healthcheck or not |
-| retry_threshold_in_minutes | Minute threshold to determine when to start retrying objects stuck in in_progress folder |
 
 [Adding QBE Refs Readme](./QBE_REFS.md)
 
@@ -225,19 +224,9 @@ It helps because:
 1. If the request fails, future requests won't contain the object
 2. It allows us to retry valid objects that may have failed simply because they were in the same request as an invalid objects
 
-When the QBWC sends a response back the integration, we run through all the information in the response. Then, we look through the `flowlink_in_progress` folder for any objects to retry. An object only gets retried if all of the following are true:
-
-* **The healthcheck is not failing:** We don't want to retry any objects if the QBWC is down
-* **The object's last_modified is past a certain threshold:** If the object has been sitting in the `flowlink_in_progress` folder for a very short period of time, we should leave it be in case it gets moved out on subsequent requests (See **Retry Threshold** below )
-* **The object has not surpassed the retry limit:** Once we retry an object that gets stuck in the `flowlink_in_progress` folder 3 times, we'll stop retrying it.
+When the QBWC sends a response back the integration, we run through all the information in the response. Then, we look through the `flowlink_in_progress` folder for any objects to retry. An object only gets retried if the object has not surpassed the retry limit. Once we retry an object that gets stuck in the `flowlink_in_progress` folder 3 times, we'll stop retrying it.
 
 When retrying an object, we move it to the `flowlink_pending` folder or the `flowlink_two_phase_pending` folder, based on the object type.
-
-#### Retry Threshold
-
-30 minutes is the default amount of time we use to check if an object has been stuck in the `flowlink_in_progress` folder long enough to retry.
-
-Sometimes clients will need to run their QBWC at much slower rates, so you may override this default using the config param `retry_threshold_in_minutes`
 
 ### Running the Health Check
 

--- a/lib/persistence/object.rb
+++ b/lib/persistence/object.rb
@@ -873,16 +873,16 @@ module Persistence
 
       now = Time.now.utc
       difference_in_minutes = (now - last_modified) / 60.0
-      difference_in_minutes <= retry_pending_threshold_mins
+      difference_in_minutes <= retry_pending_threshold_min_amount
     end
 
-    def retry_pending_threshold_mins
+    def retry_pending_threshold_min_amount
       begin
         # Threshold should be at least 5 minutes to allow for connector to run a couple times
-        param_as_int = config[:retry_pending_threshold_mins].to_i
+        param_as_int = config[:retry_pending_threshold_min_amount].to_i
         param_as_int < 5 ? DEFAULT_PENDING_THRESHOLD_MINS : param_as_int
       rescue NoMethodError => e
-        raise "The param retry_pending_threshold_mins may be incorrect. It should be an integer value or removed so the default value (30) is used. Error Message: #{e.message}")
+        raise e, "The param retry_pending_threshold_min_amount may be incorrect. It should be an integer value or removed so the default value (30) is used. Error Message: #{e.message}"
       end
     end
   end

--- a/lib/persistence/object.rb
+++ b/lib/persistence/object.rb
@@ -14,9 +14,7 @@ module Persistence
     )
 
     IDS_TO_LOG_S3_OBJ_MOVEMENT = ENV.fetch('IDS_TO_LOG', '').split(',')
-
-    DEFAULT_PENDING_THRESHOLD_MINS = 30
-    RETRY_CUTOFF = 3
+    RETRY_CUTOFF = ENV.fetch('RETRY_CUTOFF', 3)
 
     class << self
       def handle_error(config, error_context, object_type, request_id)

--- a/lib/persistence/object.rb
+++ b/lib/persistence/object.rb
@@ -479,10 +479,11 @@ module Persistence
           new_file_name = "#{path.base_name}/#{destination_folder_name}/#{reverted_filename}"
           amazon_s3.export file_name: new_file_name, objects: [s3_object_json]
         else
-          # TODO: 
-          # Tag this in_progress object with the correct error message?
-          # Create a notification maybe to send to FL?
-          # "The object failed, but a newer one exists, so we aren't going to retry this one"
+          error_obj = {
+            message: "This #{object_type.singularize} never finshed syncing to QuickBooks Desktop. FlowLink attempted to retry the sync, but found a more update object with the same ID.",
+            context: 'Attempting to retry sync of out of date object'
+          }
+          create_error_notifications(error_obj, object_type, s3_object_json['request_id'])
         end
       end
     end

--- a/lib/persistence/object.rb
+++ b/lib/persistence/object.rb
@@ -474,7 +474,7 @@ module Persistence
         new_version_of_object = amazon_s3.bucket.object("#{path.base_name}/#{destination_folder_name}/#{reverted_filename}.json")
 
         unless new_version_of_object.exists?
-          new_file_name = "#{path.base_name_w_bucket}/#{destination_folder_name}/#{reverted_filename}"
+          new_file_name = "#{path.base_name}/#{destination_folder_name}/#{reverted_filename}"
           amazon_s3.export file_name: new_file_name, objects: [s3_object_json]
         else
           # MARCTODO: 
@@ -873,7 +873,7 @@ module Persistence
 
       now = Time.now.utc
       difference_in_minutes = (now - last_modified) / 60.0
-      difference_in_minutes <= retry_pending_threshold_min_amount
+      difference_in_minutes > retry_pending_threshold_min_amount
     end
 
     def retry_pending_threshold_min_amount

--- a/lib/persistence/object.rb
+++ b/lib/persistence/object.rb
@@ -882,8 +882,7 @@ module Persistence
         param_as_int = config[:retry_pending_threshold_mins].to_i
         param_as_int < 5 ? DEFAULT_PENDING_THRESHOLD_MINS : param_as_int
       rescue NoMethodError => e
-        puts "HQ(WDUNQIDNQNDUQWNNDUI"
-        raise NoMethodError.new("The param retry_pending_threshold_mins may be incorrect. It should be an integer value or removed so the default value (30) is used. Error Message: #{e.message}")
+        raise "The param retry_pending_threshold_mins may be incorrect. It should be an integer value or removed so the default value (30) is used. Error Message: #{e.message}")
       end
     end
   end

--- a/lib/persistence/object.rb
+++ b/lib/persistence/object.rb
@@ -461,7 +461,7 @@ module Persistence
         object_type, identifier, _ = filename.split('_')
 
         s3_object_json = amazon_s3.convert_download('json', s3_object.get.body.read).first
-        next unless should_retry_pending_object?(s3_object_json, s3_object.last_modified)
+        next unless should_retry_in_progress_object?(s3_object_json, s3_object.last_modified)
 
         # Remove old object and update counter
         amazon_s3.bucket.object(s3_object.key).delete
@@ -861,7 +861,7 @@ module Persistence
       IDS_TO_LOG_S3_OBJ_MOVEMENT.include?(id)
     end
 
-    def should_retry_pending_object?(s3_object_json, last_modified)
+    def should_retry_in_progress_object?(s3_object_json, last_modified)
       s3_object_json['qbe_integration_retry_counter'].to_i < RETRY_CUTOFF &&
       is_old_enough_to_be_moved?(last_modified)
     end
@@ -872,16 +872,16 @@ module Persistence
 
       now = Time.now.utc
       difference_in_minutes = (now - last_modified) / 60.0
-      difference_in_minutes > retry_pending_threshold_min_amount
+      difference_in_minutes > retry_in_progress_threshold_amount
     end
 
-    def retry_pending_threshold_min_amount
+    def retry_in_progress_threshold_amount
       begin
         # Threshold should be at least 5 minutes to allow for connector to run a couple times
-        param_as_int = config[:retry_pending_threshold_min_amount].to_i
+        param_as_int = config[:retry_threshold_in_minutes].to_i
         param_as_int < 5 ? DEFAULT_PENDING_THRESHOLD_MINS : param_as_int
       rescue NoMethodError => e
-        raise e, "The param retry_pending_threshold_min_amount may be incorrect. It should be an integer value or removed so the default value (30) is used. Error Message: #{e.message}"
+        raise e, "The param retry_threshold_in_minutes may be incorrect. It should be an integer value or removed so the default value (30) is used. Error Message: #{e.message}"
       end
     end
   end

--- a/lib/persistence/object.rb
+++ b/lib/persistence/object.rb
@@ -467,7 +467,7 @@ module Persistence
         amazon_s3.bucket.object(s3_object.key).delete
         s3_object_json['qbe_integration_retry_counter'] = s3_object_json['qbe_integration_retry_counter'].to_i + 1
 
-        @payload_key = object_type # Need to set here => `two_phase?` uses payload_key
+        @payload_key = object_type # Need to set here because `two_phase?` uses payload_key
 
         reverted_filename = "#{object_type.pluralize}_#{identifier}_.json"
         destination_folder_name = two_phase? ? path.two_phase_pending : path.pending
@@ -477,7 +477,7 @@ module Persistence
           new_file_name = "#{path.base_name}/#{destination_folder_name}/#{reverted_filename}"
           amazon_s3.export file_name: new_file_name, objects: [s3_object_json]
         else
-          # MARCTODO: 
+          # TODO: 
           # Tag this in_progress object with the correct error message?
           # Create a notification maybe to send to FL?
           # "The object failed, but a newer one exists, so we aren't going to retry this one"
@@ -868,7 +868,6 @@ module Persistence
 
     def is_old_enough_to_be_moved?(last_modified)
       s3_settings = Persistence::Settings.new(config)
-      # If web connector is off/stuck, we shouldn't necesarily retry these?
       return false if s3_settings.healthceck_is_failing?
 
       now = Time.now.utc

--- a/lib/qbwc/response/all.rb
+++ b/lib/qbwc/response/all.rb
@@ -82,7 +82,7 @@ module QBWC
       def process(config = {})
         puts({connection: config[:connection_id], message: "Processing response", response_hash: response_hash})
 
-        response_hash.map do |key, value|
+        finished_processing = response_hash.map do |key, value|
 
           class_name = "QBWC::Response::#{key}".constantize
           value = value.is_a?(Hash)? [value] : Array(value)
@@ -117,6 +117,11 @@ module QBWC
             response_processor.handle_error(errors, config)
           end
         end
+
+        config  = config.merge(origin: 'flowlink', connection_id: config[:connection_id]).with_indifferent_access
+        Persistence::Object.new(config, {}).retry_in_progress_objects_that_are_stuck
+
+        finished_processing
       end
 
       private

--- a/spec/cassettes/persistence/move_in_progress.yml
+++ b/spec/cassettes/persistence/move_in_progress.yml
@@ -1,0 +1,348 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/?encoding-type=url&prefix=rspec-and-vcr/flowlink_in_progress
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200721T200248Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - bZ0Trpk1BOYybMwGXDfnPNIqrGCEqpVC6Pw9EbRaWJfbYPAQ6FMRRCZowF6peDbj+qhH6Yt+FC8=
+      X-Amz-Request-Id:
+      - BFF3D989BB5CB215
+      Date:
+      - Tue, 21 Jul 2020 20:02:49 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>quickbooks-desktop-integration</Name><Prefix>rspec-and-vcr/flowlink_in_progress</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>rspec-and-vcr/flowlink_in_progress/products_1234-test_.json</Key><LastModified>2020-07-21T19:54:30.000Z</LastModified><ETag>&quot;d4fe8071a4829f8807e7a8d652be2beb&quot;</ETag><Size>79</Size><Owner><ID>b61b1cd6d8e875c0b7fcfa5abc6858b8af2ecd2d85c32f240640d62ca0b0b750</ID><DisplayName>nurelm</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+    http_version: 
+  recorded_at: Tue, 21 Jul 2020 20:02:48 GMT
+- request:
+    method: get
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_in_progress/products_1234-test_.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200721T200248Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - 1Q2dqgXcGBTS9Mj9sH0t4qVxaqHLjNdIBFtNxiNiYCCC22toYknUlNn28NLe6+yZtOJWG1mco/8=
+      X-Amz-Request-Id:
+      - 2X2JDW1N4X1YAZDG
+      Date:
+      - Tue, 21 Jul 2020 20:02:49 GMT
+      Last-Modified:
+      - Tue, 21 Jul 2020 19:54:30 GMT
+      Etag:
+      - '"d4fe8071a4829f8807e7a8d652be2beb"'
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - ''
+      Content-Length:
+      - '79'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: '[{"id":"1234-test","product_id":"1234-test","qbe_integration_retry_counter":1}]'
+    http_version: 
+  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+- request:
+    method: get
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/?encoding-type=url&prefix=rspec-and-vcr/settings/healthcheck
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200721T200249Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - VPUFiJBt8dFgnaNHK38uako0hMlUTovmNRAIKdZBbYDY/mND1YoEGU8GKlVJE4f+4CeAsIEX1qA=
+      X-Amz-Request-Id:
+      - 99783A8B5F38909B
+      Date:
+      - Tue, 21 Jul 2020 20:02:50 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>quickbooks-desktop-integration</Name><Prefix>rspec-and-vcr/settings/healthcheck</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated></ListBucketResult>
+    http_version: 
+  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+- request:
+    method: delete
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_in_progress/products_1234-test_.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200721T200249Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Amz-Id-2:
+      - dbxHK2kNEc3NY6cGPr/HgERZSG+xQcDpIlcVLmkmukJz9kS1tSX90D/aF8YQbpUqNqxYtSaEvHM=
+      X-Amz-Request-Id:
+      - 69959C41BF34CA7B
+      Date:
+      - Tue, 21 Jul 2020 20:02:50 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+- request:
+    method: head
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_pending/products_1234-test_.json.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200721T200249Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Amz-Request-Id:
+      - 8D3480C01921B530
+      X-Amz-Id-2:
+      - UUlu5yI6t6ATx+Od1X80UtsteHmBN2hffLu/lIPsIIfJ/FIuUSygl4bZbav9tk9ridX2IalUu0o=
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 21 Jul 2020 20:02:49 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+- request:
+    method: head
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200721T200249Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - wk1ao7SNQcsAeByRcM8PV5sotNu5pBGrnB1BxFPB3Cx1CoQQhZnS0BHTSlMhIeefMGW8OUVYh4s=
+      X-Amz-Request-Id:
+      - 834BD184DC7F9F49
+      Date:
+      - Tue, 21 Jul 2020 20:02:50 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+- request:
+    method: put
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_pending/products_1234-test_.json
+    body:
+      encoding: UTF-8
+      string: '[{"id":"1234-test","product_id":"1234-test","qbe_integration_retry_counter":2}]'
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - 3VbAeTFUbvi5cbw3TMX8HA==
+      X-Amz-Date:
+      - 20200721T200249Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - 00fe5f02792f82000d902dcf5da3c7e07b2963a2d4ebbdbd22f2f7ddf7f9f916
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '79'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - 8szRQiShFRP8d3PuV8F0zoKVC8DHnTcWuZBcB3KQYqaagt/pd9CtvkWzVH265G8QMLlC48JKQCE=
+      X-Amz-Request-Id:
+      - FD369A72E8E6E4A0
+      Date:
+      - Tue, 21 Jul 2020 20:02:50 GMT
+      Etag:
+      - '"dd56c07931546ef8b971bc374cc5fc1c"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/persistence/move_in_progress.yml
+++ b/spec/cassettes/persistence/move_in_progress.yml
@@ -1,8 +1,8 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/?encoding-type=url&prefix=rspec-and-vcr/flowlink_in_progress
+    method: head
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/
     body:
       encoding: ASCII-8BIT
       string: ''
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
       X-Amz-Date:
-      - 20200721T200248Z
+      - 20200810T174628Z
       Host:
       - quickbooks-desktop-integration.s3.amazonaws.com
       X-Amz-Content-Sha256:
@@ -31,11 +31,211 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - bZ0Trpk1BOYybMwGXDfnPNIqrGCEqpVC6Pw9EbRaWJfbYPAQ6FMRRCZowF6peDbj+qhH6Yt+FC8=
+      - nfgYNgMg7XY/hatejty6K7VmXanD+ggjwmgjyesHaO/oIJXCRQpyrZjagkq1uqB2cQqaNzC4giE=
       X-Amz-Request-Id:
-      - BFF3D989BB5CB215
+      - 0C30C3764D1B6CB8
       Date:
-      - Tue, 21 Jul 2020 20:02:49 GMT
+      - Mon, 10 Aug 2020 17:46:29 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:28 GMT
+- request:
+    method: put
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_sessions/e6f5584b-3203-449b-9979-8dcf24992a96_.json
+    body:
+      encoding: UTF-8
+      string: '[{"id":"1234-test","product_id":"1234-test","qbe_integration_retry_counter":1}]'
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - 1P6AcaSCn4gH56jWUr4r6w==
+      X-Amz-Date:
+      - 20200810T174629Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - 7d38901cffaffbb375b9b7f0478733d21229cd6a8e53d0c64e9a3cf7e146097d
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '79'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - dB15FpObmmNdIZnV5x8UB6L8IUmd1jEPWC5ScJWXgcu9RbO3QuEC7LjDJl43cE5hPhWVApdh+yI=
+      X-Amz-Request-Id:
+      - 28A0D965D61E3B7E
+      Date:
+      - Mon, 10 Aug 2020 17:46:30 GMT
+      Etag:
+      - '"d4fe8071a4829f8807e7a8d652be2beb"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:29 GMT
+- request:
+    method: head
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174629Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - 7B1hAfFzqz5klrfWuSst4HGleB6OHq/JGkSa83BL5HiqmB0fHF5txCaXOsxff4zaRqPWuDIZmnE=
+      X-Amz-Request-Id:
+      - 15106B9226AB6C45
+      Date:
+      - Mon, 10 Aug 2020 17:46:30 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:29 GMT
+- request:
+    method: put
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_in_progress/products_1234-test_.json
+    body:
+      encoding: UTF-8
+      string: '[{"id":"1234-test","product_id":"1234-test","qbe_integration_retry_counter":1,"request_id":"e6f5584b-3203-449b-9979-8dcf24992a96_"}]'
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - C+Yku2K5/7a6e+dOc/o1QQ==
+      X-Amz-Date:
+      - 20200810T174629Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - 20a3ba6d1b3a0b8a58b7c95b67c88131e01c2bb984d1fc8094c842e3658e6380
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '132'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - POA1RXQ9Pz8NCa45XIqAasu13lUDCkTnno5Bb0mHTWK4RZ8YeQwlbACxaUjjoY2q2D/Qvn6R3bw=
+      X-Amz-Request-Id:
+      - 95FCFA69675667FE
+      Date:
+      - Mon, 10 Aug 2020 17:46:30 GMT
+      Etag:
+      - '"0be624bb62b9ffb6ba7be74e73fa3541"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:29 GMT
+- request:
+    method: get
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/?encoding-type=url&prefix=rspec-and-vcr/flowlink_in_progress
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174629Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - dRl0nUf9bG5BHW9pSk2M4BEmfgWvEKIeKse4xcnJKkZzWAqe2wYsUzFv6mTLLGxsExoZ0+o/fAU=
+      X-Amz-Request-Id:
+      - DHDK8MBTCT2P2GCY
+      Date:
+      - Mon, 10 Aug 2020 17:46:30 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -48,9 +248,9 @@ http_interactions:
       encoding: UTF-8
       string: |-
         <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>quickbooks-desktop-integration</Name><Prefix>rspec-and-vcr/flowlink_in_progress</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>rspec-and-vcr/flowlink_in_progress/products_1234-test_.json</Key><LastModified>2020-07-21T19:54:30.000Z</LastModified><ETag>&quot;d4fe8071a4829f8807e7a8d652be2beb&quot;</ETag><Size>79</Size><Owner><ID>b61b1cd6d8e875c0b7fcfa5abc6858b8af2ecd2d85c32f240640d62ca0b0b750</ID><DisplayName>nurelm</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>quickbooks-desktop-integration</Name><Prefix>rspec-and-vcr/flowlink_in_progress</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>rspec-and-vcr/flowlink_in_progress/products_1234-test_.json</Key><LastModified>2020-08-10T17:46:30.000Z</LastModified><ETag>&quot;0be624bb62b9ffb6ba7be74e73fa3541&quot;</ETag><Size>132</Size><Owner><ID>b61b1cd6d8e875c0b7fcfa5abc6858b8af2ecd2d85c32f240640d62ca0b0b750</ID><DisplayName>nurelm</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
     http_version: 
-  recorded_at: Tue, 21 Jul 2020 20:02:48 GMT
+  recorded_at: Mon, 10 Aug 2020 17:46:29 GMT
 - request:
     method: get
     uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_in_progress/products_1234-test_.json
@@ -65,7 +265,7 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
       X-Amz-Date:
-      - 20200721T200248Z
+      - 20200810T174629Z
       Host:
       - quickbooks-desktop-integration.s3.amazonaws.com
       X-Amz-Content-Sha256:
@@ -82,79 +282,28 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - 1Q2dqgXcGBTS9Mj9sH0t4qVxaqHLjNdIBFtNxiNiYCCC22toYknUlNn28NLe6+yZtOJWG1mco/8=
+      - ZNn8nEfBxI6bWHwh2Tc6l2rcEYqgtJjzd4XfzloRIIWF7szF6rLma3pqvPPBN0/J3/um5f07jv4=
       X-Amz-Request-Id:
-      - 2X2JDW1N4X1YAZDG
+      - C9DF4F797E87DAF5
       Date:
-      - Tue, 21 Jul 2020 20:02:49 GMT
+      - Mon, 10 Aug 2020 17:46:30 GMT
       Last-Modified:
-      - Tue, 21 Jul 2020 19:54:30 GMT
+      - Mon, 10 Aug 2020 17:46:30 GMT
       Etag:
-      - '"d4fe8071a4829f8807e7a8d652be2beb"'
+      - '"0be624bb62b9ffb6ba7be74e73fa3541"'
       Accept-Ranges:
       - bytes
       Content-Type:
       - ''
       Content-Length:
-      - '79'
+      - '132'
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
-      string: '[{"id":"1234-test","product_id":"1234-test","qbe_integration_retry_counter":1}]'
+      string: '[{"id":"1234-test","product_id":"1234-test","qbe_integration_retry_counter":1,"request_id":"e6f5584b-3203-449b-9979-8dcf24992a96_"}]'
     http_version: 
-  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
-- request:
-    method: get
-    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/?encoding-type=url&prefix=rspec-and-vcr/settings/healthcheck
-    body:
-      encoding: ASCII-8BIT
-      string: ''
-    headers:
-      Content-Type:
-      - ''
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
-      X-Amz-Date:
-      - 20200721T200249Z
-      Host:
-      - quickbooks-desktop-integration.s3.amazonaws.com
-      X-Amz-Content-Sha256:
-      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-      Authorization:
-      - AUTHORIZATION
-      Content-Length:
-      - '0'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Amz-Id-2:
-      - VPUFiJBt8dFgnaNHK38uako0hMlUTovmNRAIKdZBbYDY/mND1YoEGU8GKlVJE4f+4CeAsIEX1qA=
-      X-Amz-Request-Id:
-      - 99783A8B5F38909B
-      Date:
-      - Tue, 21 Jul 2020 20:02:50 GMT
-      X-Amz-Bucket-Region:
-      - us-east-1
-      Content-Type:
-      - application/xml
-      Transfer-Encoding:
-      - chunked
-      Server:
-      - AmazonS3
-    body:
-      encoding: UTF-8
-      string: |-
-        <?xml version="1.0" encoding="UTF-8"?>
-        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>quickbooks-desktop-integration</Name><Prefix>rspec-and-vcr/settings/healthcheck</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated></ListBucketResult>
-    http_version: 
-  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+  recorded_at: Mon, 10 Aug 2020 17:46:29 GMT
 - request:
     method: delete
     uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_in_progress/products_1234-test_.json
@@ -169,7 +318,7 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
       X-Amz-Date:
-      - 20200721T200249Z
+      - 20200810T174629Z
       Host:
       - quickbooks-desktop-integration.s3.amazonaws.com
       X-Amz-Content-Sha256:
@@ -186,18 +335,18 @@ http_interactions:
       message: No Content
     headers:
       X-Amz-Id-2:
-      - dbxHK2kNEc3NY6cGPr/HgERZSG+xQcDpIlcVLmkmukJz9kS1tSX90D/aF8YQbpUqNqxYtSaEvHM=
+      - dWWXAdP+I2tZf5DQm3CTLOms2qLP1QKmZmlJGaJU3YXxGwlMSDf3W1e5Mn/ZXHn62t7NZsUQq0Q=
       X-Amz-Request-Id:
-      - 69959C41BF34CA7B
+      - D08B7B5DF33ABCE8
       Date:
-      - Tue, 21 Jul 2020 20:02:50 GMT
+      - Mon, 10 Aug 2020 17:46:31 GMT
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+  recorded_at: Mon, 10 Aug 2020 17:46:30 GMT
 - request:
     method: head
     uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_pending/products_1234-test_.json.json
@@ -212,7 +361,7 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
       X-Amz-Date:
-      - 20200721T200249Z
+      - 20200810T174630Z
       Host:
       - quickbooks-desktop-integration.s3.amazonaws.com
       X-Amz-Content-Sha256:
@@ -229,22 +378,22 @@ http_interactions:
       message: Not Found
     headers:
       X-Amz-Request-Id:
-      - 8D3480C01921B530
+      - 9D0CAFB6EC9C3EC8
       X-Amz-Id-2:
-      - UUlu5yI6t6ATx+Od1X80UtsteHmBN2hffLu/lIPsIIfJ/FIuUSygl4bZbav9tk9ridX2IalUu0o=
+      - SmjF5FLcquxXS79ba/Sciq3yPGIs8tc5dF3f7ogvKMudNXqnHBijB6eqEZB+UNEQFBZLasuDvjI=
       Content-Type:
       - application/xml
       Transfer-Encoding:
       - chunked
       Date:
-      - Tue, 21 Jul 2020 20:02:49 GMT
+      - Mon, 10 Aug 2020 17:46:29 GMT
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+  recorded_at: Mon, 10 Aug 2020 17:46:30 GMT
 - request:
     method: head
     uri: https://quickbooks-desktop-integration.s3.amazonaws.com/
@@ -259,7 +408,7 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
       X-Amz-Date:
-      - 20200721T200249Z
+      - 20200810T174630Z
       Host:
       - quickbooks-desktop-integration.s3.amazonaws.com
       X-Amz-Content-Sha256:
@@ -276,11 +425,11 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - wk1ao7SNQcsAeByRcM8PV5sotNu5pBGrnB1BxFPB3Cx1CoQQhZnS0BHTSlMhIeefMGW8OUVYh4s=
+      - 5usFLlJVKOt47HPmdI1YVF/x6xfTdMxIfaLkD7gwDrf7KtLksD7n07zE2RUOokgN4/BXVhCONP8=
       X-Amz-Request-Id:
-      - 834BD184DC7F9F49
+      - 6E96B8DE6142714A
       Date:
-      - Tue, 21 Jul 2020 20:02:50 GMT
+      - Mon, 10 Aug 2020 17:46:31 GMT
       X-Amz-Bucket-Region:
       - us-east-1
       Content-Type:
@@ -293,13 +442,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+  recorded_at: Mon, 10 Aug 2020 17:46:31 GMT
 - request:
     method: put
     uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_pending/products_1234-test_.json
     body:
       encoding: UTF-8
-      string: '[{"id":"1234-test","product_id":"1234-test","qbe_integration_retry_counter":2}]'
+      string: '[{"id":"1234-test","product_id":"1234-test","qbe_integration_retry_counter":2,"request_id":"e6f5584b-3203-449b-9979-8dcf24992a96_"}]'
     headers:
       Content-Type:
       - ''
@@ -310,17 +459,17 @@ http_interactions:
       Expect:
       - 100-continue
       Content-Md5:
-      - 3VbAeTFUbvi5cbw3TMX8HA==
+      - U1m9j4F3kSYczpn81ejbSw==
       X-Amz-Date:
-      - 20200721T200249Z
+      - 20200810T174631Z
       Host:
       - quickbooks-desktop-integration.s3.amazonaws.com
       X-Amz-Content-Sha256:
-      - 00fe5f02792f82000d902dcf5da3c7e07b2963a2d4ebbdbd22f2f7ddf7f9f916
+      - 1fc0165e5832a837b9fe110454793f3b9c83702a034c578ff15461139d43f399
       Authorization:
       - AUTHORIZATION
       Content-Length:
-      - '79'
+      - '132'
       Accept:
       - "*/*"
   response:
@@ -329,13 +478,13 @@ http_interactions:
       message: OK
     headers:
       X-Amz-Id-2:
-      - 8szRQiShFRP8d3PuV8F0zoKVC8DHnTcWuZBcB3KQYqaagt/pd9CtvkWzVH265G8QMLlC48JKQCE=
+      - "/rnyZqhZ0pXFMVcapXEx88vvbDe/ztC3ZIWpYJ+/920Vkd54RgUlBSHZFVbuqL3luTHYHfFyz5w="
       X-Amz-Request-Id:
-      - FD369A72E8E6E4A0
+      - FR0K4JFG5N7M5YCJ
       Date:
-      - Tue, 21 Jul 2020 20:02:50 GMT
+      - Mon, 10 Aug 2020 17:46:32 GMT
       Etag:
-      - '"dd56c07931546ef8b971bc374cc5fc1c"'
+      - '"5359bd8f817791261cce99fcd5e8db4b"'
       Content-Length:
       - '0'
       Server:
@@ -344,5 +493,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 21 Jul 2020 20:02:49 GMT
+  recorded_at: Mon, 10 Aug 2020 17:46:31 GMT
 recorded_with: VCR 3.0.3

--- a/spec/cassettes/persistence/remove_in_progress_and_generate_notification.yml
+++ b/spec/cassettes/persistence/remove_in_progress_and_generate_notification.yml
@@ -1,0 +1,658 @@
+---
+http_interactions:
+- request:
+    method: head
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174631Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - Sy2j0T6jY6Xnxnz+agX7K6XdkEUfFjit3+cygG2BL8DlfhSWFOb6cpEUDND+Lc+G8VblGqEZGXk=
+      X-Amz-Request-Id:
+      - EB4B151C1CBD5B4D
+      Date:
+      - Mon, 10 Aug 2020 17:46:32 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:31 GMT
+- request:
+    method: put
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_sessions/96f86a2d-585c-4dda-997b-3a78d806cf7d_.json
+    body:
+      encoding: UTF-8
+      string: '[{"id":"5678-test","product_id":"5678-test","qbe_integration_retry_counter":3}]'
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - C3JdXhSKPge37D0+Sv+zCg==
+      X-Amz-Date:
+      - 20200810T174631Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e118b81ea0d4d17f9fcbb6b3aabf9bb1b047917bd346c02c1a59f074c533d6e5
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '79'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - Vih8TVcOm0e+UBC5s5hVOoaF76xK7etM0tpSm0XyIKUG8Oq54GF+oqW2DM2z/xZrYBWHoa3JORk=
+      X-Amz-Request-Id:
+      - 3545B1B35CF9541A
+      Date:
+      - Mon, 10 Aug 2020 17:46:32 GMT
+      Etag:
+      - '"0b725d5e148a3e07b7ec3d3e4affb30a"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:31 GMT
+- request:
+    method: head
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174631Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - Kd/gLTnxdLQGw4z03uUEMHmZ75/325TDWY9JcFlJprHgR/jdYTk7TFW8Jp8Ckp+Xbr46AixoLzc=
+      X-Amz-Request-Id:
+      - 1215D6E818C020C3
+      Date:
+      - Mon, 10 Aug 2020 17:46:32 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:31 GMT
+- request:
+    method: put
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_in_progress/products_5678-test_.json
+    body:
+      encoding: UTF-8
+      string: '[{"id":"5678-test","product_id":"5678-test","qbe_integration_retry_counter":3,"request_id":"96f86a2d-585c-4dda-997b-3a78d806cf7d_"}]'
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - cqtOvFgLYUWKIyDWeZMCjA==
+      X-Amz-Date:
+      - 20200810T174631Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - 73afb15f787dfb15a3f63fb49e5284a5c4cdac148b717dfbeef0b657a1e00028
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '132'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - Zwq4BYgBuMpI/APPmmDpRzX675t29mpnGmpODKgTDt+bF9Kfp1fyTtdzlC0wT01sh5WiYkmmK50=
+      X-Amz-Request-Id:
+      - 8T2QAZ5Y9R4K9P7Y
+      Date:
+      - Mon, 10 Aug 2020 17:46:32 GMT
+      Etag:
+      - '"72ab4ebc580b61458a2320d67993028c"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:31 GMT
+- request:
+    method: get
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/?encoding-type=url&prefix=rspec-and-vcr/flowlink_in_progress
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174631Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - kr7x0QpMqXK1WTEhe8GaDo00ys1uZv3wElGrar5NtqKjBLkN3C2I5KZHRx0SruVVwXi1B24wYyk=
+      X-Amz-Request-Id:
+      - BDC1E1099771008C
+      Date:
+      - Mon, 10 Aug 2020 17:46:33 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>quickbooks-desktop-integration</Name><Prefix>rspec-and-vcr/flowlink_in_progress</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>rspec-and-vcr/flowlink_in_progress/products_5678-test_.json</Key><LastModified>2020-08-10T17:46:32.000Z</LastModified><ETag>&quot;72ab4ebc580b61458a2320d67993028c&quot;</ETag><Size>132</Size><Owner><ID>b61b1cd6d8e875c0b7fcfa5abc6858b8af2ecd2d85c32f240640d62ca0b0b750</ID><DisplayName>nurelm</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:32 GMT
+- request:
+    method: get
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_in_progress/products_5678-test_.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174632Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - JUzpsouiwkJMwDa9DTvwO9JSF17CxAkJucLiUSbF9P5xBLrpYj6Btt5/E47tqcBd1Fzi33X4Yyc=
+      X-Amz-Request-Id:
+      - CD2AD922C1F1BE64
+      Date:
+      - Mon, 10 Aug 2020 17:46:33 GMT
+      Last-Modified:
+      - Mon, 10 Aug 2020 17:46:32 GMT
+      Etag:
+      - '"72ab4ebc580b61458a2320d67993028c"'
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - ''
+      Content-Length:
+      - '132'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: '[{"id":"5678-test","product_id":"5678-test","qbe_integration_retry_counter":3,"request_id":"96f86a2d-585c-4dda-997b-3a78d806cf7d_"}]'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:32 GMT
+- request:
+    method: get
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_sessions/96f86a2d-585c-4dda-997b-3a78d806cf7d_.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174632Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - 7/u3BWUVqxJdrj6cIzC0W1Fc0ZzLjTlsRx17rynsevfgWHAbq19mms0NQzCvgdNnPAibDvl7m6c=
+      X-Amz-Request-Id:
+      - 165A381CE4D195BA
+      Date:
+      - Mon, 10 Aug 2020 17:46:33 GMT
+      Last-Modified:
+      - Mon, 10 Aug 2020 17:46:32 GMT
+      Etag:
+      - '"0b725d5e148a3e07b7ec3d3e4affb30a"'
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - ''
+      Content-Length:
+      - '79'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: '[{"id":"5678-test","product_id":"5678-test","qbe_integration_retry_counter":3}]'
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:32 GMT
+- request:
+    method: head
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174632Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - JX9Nn1Hc+9yNxhgQQhiAjlz/LY98Y6ggsXshZZx4d8finx1MgXqxIv7VqNczINXJGms/0phuUII=
+      X-Amz-Request-Id:
+      - C9774035292B751B
+      Date:
+      - Mon, 10 Aug 2020 17:46:33 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:32 GMT
+- request:
+    method: put
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_ready/notification_failed_96f86a2d-585c-4dda-997b-3a78d806cf7d_products_5678-test_.json
+    body:
+      encoding: UTF-8
+      string: '[{"message":"This product never finshed syncing to QuickBooks Desktop.
+        FlowLink retried it 3x, but each time it failed.","context":"Attempting to
+        retry sync of out of date object","object":{"id":"5678-test","product_id":"5678-test","qbe_integration_retry_counter":3},"request_id":"96f86a2d-585c-4dda-997b-3a78d806cf7d"}]'
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - 8xgE4FRzbvsz6X7Ufc/9LQ==
+      X-Amz-Date:
+      - 20200810T174632Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - 00ba4859e3edf8ee8df1da7b71d2a6dceecc8be20d26c620a9c9f86a8b9a26e9
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '320'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - O3uuxyg0BbzXa9AKJ1p8tP78essLiI0Tl4jHHBwCm6QMuoK8bTbD5LoSKpG8z0HD/VXJbm7Pou4=
+      X-Amz-Request-Id:
+      - 4182D183C543D0FB
+      Date:
+      - Mon, 10 Aug 2020 17:46:33 GMT
+      Etag:
+      - '"f31804e054736efb33e97ed47dcffd2d"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:32 GMT
+- request:
+    method: get
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/?encoding-type=url&prefix=rspec-and-vcr/flowlink_in_progress/products_5678-test_
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174632Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - jUFXmJb3YsruiSF1MBnJhwbaUl5fcc7pv16I4QTBjBLUQbksuNsJCr09dGFhF4OmZ5PnWeS4R2A=
+      X-Amz-Request-Id:
+      - 54B4DE659BFB2A73
+      Date:
+      - Mon, 10 Aug 2020 17:46:33 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>quickbooks-desktop-integration</Name><Prefix>rspec-and-vcr/flowlink_in_progress/products_5678-test_</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>rspec-and-vcr/flowlink_in_progress/products_5678-test_.json</Key><LastModified>2020-08-10T17:46:32.000Z</LastModified><ETag>&quot;72ab4ebc580b61458a2320d67993028c&quot;</ETag><Size>132</Size><Owner><ID>b61b1cd6d8e875c0b7fcfa5abc6858b8af2ecd2d85c32f240640d62ca0b0b750</ID><DisplayName>nurelm</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:32 GMT
+- request:
+    method: get
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/?encoding-type=url&prefix=rspec-and-vcr/flowlink_in_progress/products_5678-test_
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174632Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - ruu+093F8bnBtJ4wsBIuwd2Yu4kWPfHgmpnMn07qxx0iojZ2HhJGpBOaWoWSAG+nRsDxAF8/qt4=
+      X-Amz-Request-Id:
+      - 4A9180DD81678176
+      Date:
+      - Mon, 10 Aug 2020 17:46:33 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>quickbooks-desktop-integration</Name><Prefix>rspec-and-vcr/flowlink_in_progress/products_5678-test_</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>rspec-and-vcr/flowlink_in_progress/products_5678-test_.json</Key><LastModified>2020-08-10T17:46:32.000Z</LastModified><ETag>&quot;72ab4ebc580b61458a2320d67993028c&quot;</ETag><Size>132</Size><Owner><ID>b61b1cd6d8e875c0b7fcfa5abc6858b8af2ecd2d85c32f240640d62ca0b0b750</ID><DisplayName>nurelm</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:33 GMT
+- request:
+    method: put
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_failed/products_5678-test_.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Copy-Source:
+      - quickbooks-desktop-integration/rspec-and-vcr/flowlink_in_progress/products_5678-test_.json
+      X-Amz-Date:
+      - 20200810T174633Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - uoWf0ZcsQo4E07YHlGbVMF+0hQunTbYxwAMk2rZwm8hfdwiGFnQxt+G1lJf22lI+7fny7iEkaLs=
+      X-Amz-Request-Id:
+      - 15F1B648088EDFA0
+      Date:
+      - Mon, 10 Aug 2020 17:46:34 GMT
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '234'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2020-08-10T17:46:34.000Z</LastModified><ETag>&quot;72ab4ebc580b61458a2320d67993028c&quot;</ETag></CopyObjectResult>
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:33 GMT
+- request:
+    method: delete
+    uri: https://quickbooks-desktop-integration.s3.amazonaws.com/rspec-and-vcr/flowlink_in_progress/products_5678-test_.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - ''
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.10.22 ruby/2.4.2 x86_64-linux resources
+      X-Amz-Date:
+      - 20200810T174633Z
+      Host:
+      - quickbooks-desktop-integration.s3.amazonaws.com
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AUTHORIZATION
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Amz-Id-2:
+      - MkQ/ZvrUGZo4p4T1J+4yjk5sYcyDgP81WQhg90RaTvLAH0BS05PKnl3tV1GEk5njmvTE8jmujpw=
+      X-Amz-Request-Id:
+      - 673BA4CAB788935F
+      Date:
+      - Mon, 10 Aug 2020 17:46:34 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 10 Aug 2020 17:46:33 GMT
+recorded_with: VCR 3.0.3

--- a/spec/persistence/object_spec.rb
+++ b/spec/persistence/object_spec.rb
@@ -368,16 +368,16 @@ module Persistence
         VCR.use_cassette 'persistence/move_in_progress' do
           # If you need to re-run the cassette:
           # 1. Delete the cassette
-          # 2. Uncomment the 2 commented lines of code below (that start with `amazon_s3`)
+          # 2. Uncomment the 4 commented lines of code below (that start with id assignment)
           # 3. Ensure that scripts/run_tests.sh has the REAL key/secret
           # 4. Run the spec (It will create the file in S3 in the quickbooks-desktop-integration/rspec-and-vcr/flowlink_in_progress folder)
           # 5. Delete the cassette again (since we're not testing the creation of the file, but the moving of the file)
-          # 6. Comment the 2 lines of code below (that start with `amazon_s3`)
+          # 6. Comment the 2 lines of code below (that start with id assignment)
           
-          id = Persistence::Session.save(config_for_retry, object_for_retry)
-          object_for_retry["request_id"] = id
-          amazon_s3 = S3Util.new
-          amazon_s3.export file_name: file_name_for_retry, objects: [object_for_retry]
+          # id = Persistence::Session.save(config_for_retry, object_for_retry)
+          # object_for_retry["request_id"] = id
+          # amazon_s3 = S3Util.new
+          # amazon_s3.export file_name: file_name_for_retry, objects: [object_for_retry]
           
           subject = described_class.new config_for_retry
           subject.retry_in_progress_objects_that_are_stuck
@@ -389,16 +389,16 @@ module Persistence
         VCR.use_cassette 'persistence/remove_in_progress_and_generate_notification' do
           # If you need to re-run the cassette:
           # 1. Delete the cassette
-          # 2. Uncomment the 2 commented lines of code below (that start with `amazon_s3`)
+          # 2. Uncomment the 4 commented lines of code below (that start with id assignment)
           # 3. Ensure that scripts/run_tests.sh has the REAL key/secret
           # 4. Run the spec (It will create the file in S3 in the quickbooks-desktop-integration/rspec-and-vcr/flowlink_in_progress folder)
           # 5. Delete the cassette again (since we're not testing the creation of the file, but the moving of the file)
-          # 6. Comment the 2 lines of code below (that start with `amazon_s3`)
+          # 6. Comment the 4 lines of code below (that start with id assignment)
           
-          id = Persistence::Session.save(config_for_removal, object_for_removal)
-          object_for_removal["request_id"] = id
-          amazon_s3 = S3Util.new
-          amazon_s3.export file_name: file_name_for_removal, objects: [object_for_removal]
+          # id = Persistence::Session.save(config_for_removal, object_for_removal)
+          # object_for_removal["request_id"] = id
+          # amazon_s3 = S3Util.new
+          # amazon_s3.export file_name: file_name_for_removal, objects: [object_for_removal]
 
           subject = described_class.new config_for_removal
           subject.retry_in_progress_objects_that_are_stuck

--- a/spec/persistence/object_spec.rb
+++ b/spec/persistence/object_spec.rb
@@ -381,41 +381,41 @@ module Persistence
       end
     end
 
-    describe 'retry_pending_threshold_mins' do
-      let(:config) { { origin: 'flowlink', connection_id: 'rspec_testing', retry_pending_threshold_mins: retry_param_num } }
+    describe 'retry_pending_threshold_min_amount' do
+      let(:config) { { origin: 'flowlink', connection_id: 'rspec_testing', retry_pending_threshold_min_amount: retry_param_num } }
       let(:retry_param_num) { rand(100) + 5 }
 
-      describe 'given a config with no retry_pending_threshold_mins param' do
+      describe 'given a config with no retry_pending_threshold_min_amount param' do
         let(:config) { { origin: 'flowlink', connection_id: 'rspec_testing' } }
         it 'returns the default of 30' do
           subject = described_class.new(config, {})
-          expect(subject.send(:retry_pending_threshold_mins)).to eq(30)
+          expect(subject.send(:retry_pending_threshold_min_amount)).to eq(30)
         end
       end
 
-      describe 'given a config with retry_pending_threshold_mins set to less than 5' do
-        let(:config) { { origin: 'flowlink', connection_id: 'rspec_testing', retry_pending_threshold_mins: rand(5) } }
+      describe 'given a config with retry_pending_threshold_min_amount set to less than 5' do
+        let(:config) { { origin: 'flowlink', connection_id: 'rspec_testing', retry_pending_threshold_min_amount: rand(5) } }
         it 'returns the default of 30' do
           subject = described_class.new(config, {})
-          expect(subject.send(:retry_pending_threshold_mins)).to eq(30)
+          expect(subject.send(:retry_pending_threshold_min_amount)).to eq(30)
         end
       end
 
-      describe 'given a config with retry_pending_threshold_mins greater than 5' do
+      describe 'given a config with retry_pending_threshold_min_amount greater than 5' do
         it 'returns the config param as an integer' do
           subject = described_class.new(config, {})
-          expect(subject.send(:retry_pending_threshold_mins)).to eq(retry_param_num)
+          expect(subject.send(:retry_pending_threshold_min_amount)).to eq(retry_param_num)
         end
       end
 
-      describe 'given a config with retry_pending_threshold_mins set as an array or object' do
+      describe 'given a config with retry_pending_threshold_min_amount set as an array or object' do
         let(:retry_param_num) { [[], {}][rand(2)] }
         it 'raises an error' do
-          error_msg = /The param retry_pending_threshold_mins may be incorrect. It should be an integer value or removed so the default value (30) is used. Error Message:/
+          error_msg = /The param retry_pending_threshold_min_amount may be incorrect. It should be an integer value/
           subject = described_class.new(config, {})
           expect {
-            subject.send(:retry_pending_threshold_mins)
-          }.to raise_error(error_msg)
+            subject.send(:retry_pending_threshold_min_amount)
+          }.to raise_error(NoMethodError, error_msg)
         end
       end
       

--- a/spec/qbwc/response/all_spec.rb
+++ b/spec/qbwc/response/all_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe QBWC::Response::All do
+  before(:each) do
+    Aws.config[:stub_responses] = true
+  end
+
   subject { described_class.new Factory.item_query_rs_qbxml }
 
   describe '#process' do


### PR DESCRIPTION
This is the first phase of the Error Report functionality that we want to use.

This will allow objects that get "stuck" in the flowlink_in_progress folder to be retried a certain number of times.

Still to do:
1. When we attempt to retry, but find a newer version of the same object being synced, we should generate a failure error notification that alerts the user in FL why the object failed to sync.
2. Add an error report endpoint to grab all objects that have continually failed syncing and are doomed to an eternity in the flowlink_in_progress folder