### PR TITLE
Added polling_without_timestamp method for most query responses

### DIFF
--- a/lib/qbwc/response/credit_memo_query_rs.rb
+++ b/lib/qbwc/response/credit_memo_query_rs.rb
@@ -27,7 +27,7 @@ module QBWC
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == 'origin'}
 
           poll_persistence = Persistence::Polling.new(config, payload)
-          poll_persistence.save_for_polling
+          poll_persistence.save_for_polling_without_timestamp
 
           credit_params['creditmemos']['quickbooks_since'] = last_time_modified
           credit_params['creditmemos']['quickbooks_force_config'] = 'true'

--- a/lib/qbwc/response/customer_query_rs.rb
+++ b/lib/qbwc/response/customer_query_rs.rb
@@ -27,7 +27,7 @@ module QBWC
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == 'origin'}
 
           poll_persistence = Persistence::Polling.new(config, payload)
-          poll_persistence.save_for_polling
+          poll_persistence.save_for_polling_without_timestamp
 
           customer_params['customers']['quickbooks_since'] = last_time_modified
           customer_params['customers']['quickbooks_force_config'] = 'true'

--- a/lib/qbwc/response/invoice_query_rs.rb
+++ b/lib/qbwc/response/invoice_query_rs.rb
@@ -27,7 +27,7 @@ module QBWC
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == 'origin'}
 
           poll_persistence = Persistence::Polling.new(config, payload)
-          poll_persistence.save_for_polling
+          poll_persistence.save_for_polling_without_timestamp
 
           invoice_params['invoices']['quickbooks_since'] = last_time_modified
           invoice_params['invoices']['quickbooks_force_config'] = 'true'

--- a/lib/qbwc/response/item_inventory_assembly_query_rs.rb
+++ b/lib/qbwc/response/item_inventory_assembly_query_rs.rb
@@ -28,7 +28,7 @@ module QBWC
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == "origin"}
 
           poll_persistence = Persistence::Polling.new(config, payload)
-          poll_persistence.save_for_polling
+          poll_persistence.save_for_polling_without_timestamp
         end
 
         if inventoryassemblyproduct_params

--- a/lib/qbwc/response/purchase_order_query_rs.rb
+++ b/lib/qbwc/response/purchase_order_query_rs.rb
@@ -27,7 +27,7 @@ module QBWC
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == 'origin'}
 
           poll_persistence = Persistence::Polling.new(config, payload)
-          poll_persistence.save_for_polling
+          poll_persistence.save_for_polling_without_timestamp
 
           purchaseorder_params['purchaseorders']['quickbooks_since'] = last_time_modified
           purchaseorder_params['purchaseorders']['quickbooks_force_config'] = 'true'

--- a/lib/qbwc/response/sales_order_query_rs.rb
+++ b/lib/qbwc/response/sales_order_query_rs.rb
@@ -27,7 +27,7 @@ module QBWC
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == "origin"}
 
           poll_persistence = Persistence::Polling.new(config, payload)
-          poll_persistence.save_for_polling
+          poll_persistence.save_for_polling_without_timestamp
 
           order_params['orders']['quickbooks_since'] = last_time_modified
           order_params['orders']['quickbooks_force_config'] = 'true'

--- a/lib/qbwc/response/vendor_query_rs.rb
+++ b/lib/qbwc/response/vendor_query_rs.rb
@@ -27,7 +27,7 @@ module QBWC
           config = { origin: 'quickbooks' }.merge config.reject{|k,v| k == :origin || k == "origin"}
 
           poll_persistence = Persistence::Polling.new(config, payload)
-          poll_persistence.save_for_polling
+          poll_persistence.save_for_polling_without_timestamp
 
           vendor_params['vendors']['quickbooks_since'] = last_time_modified
           vendor_params['vendors']['quickbooks_force_config'] = 'true'


### PR DESCRIPTION
Any reason NOT to call this for these classes?